### PR TITLE
Fix comments in module export list

### DIFF
--- a/syntaxes/haskell.tmLanguage
+++ b/syntaxes/haskell.tmLanguage
@@ -613,6 +613,10 @@
 					<key>name</key>
 					<string>meta.other.unknown.haskell</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>#comments</string>
+				</dict>
 			</array>
 		</dict>
 		<key>module_name</key>


### PR DESCRIPTION
This fixes bad comment highlighting in module export list and resolves issue #2.

I have also submitted a pull request to the original Textmate Haskell bundle.