### PR TITLE
Wiring Literate Haskell grammar

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     },
     "bugs": {
         "url": "https://github.com/JustusAdam/language-haskell/issues",
-        "email": "dev@justus.science"    
+        "email": "dev@justus.science"
     },
     "categories": [
         "Languages",
@@ -45,6 +45,10 @@
                 ".cabal"
             ],
             "configuration": "./cabal.configuration.json"
+        }, {
+            "id": "literate haskell",
+            "aliases": ["Literate Haskell", "literate Haskell"],
+            "extensions": [".lhs"]
         }],
         "grammars": [{
             "language": "haskell",
@@ -54,6 +58,10 @@
             "language": "cabal",
             "scopeName": "source.cabal",
             "path": "./syntaxes/cabal.tmLanguage"
+        }, {
+            "language": "literate haskell",
+            "scopeName": "text.tex.latex.haskell",
+            "path": "./syntaxes/literateHaskell.tmLanguage"
         }],
         "snippets": [{
             "language": "haskell",


### PR DESCRIPTION
Changes to package.json to enable Literate Haskell Grammar, fixing #7.

I've tested with some personal files (bird style)
![is-it-right-question-mark](https://cloud.githubusercontent.com/assets/15656072/21197445/a117d4fa-c222-11e6-9e45-fff4111ae858.png)

And with a small piece of LaTex.
![latex-looks-good](https://cloud.githubusercontent.com/assets/15656072/21197454/a6cb0c32-c222-11e6-8a79-87a52540bee2.png)



