### PR TITLE
Remove empty reference to old snippets file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1 - 07.06.2017
+
+- Removed snippets contribution from package.json (fixes `ENOENT: no such file or directory` error)
+
 ## 2.2.0 - 26.05.2017
 
 - Removed snippets by request from @Eugleo

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "language-haskell",
     "displayName": "Haskell Syntax Highlighting",
 	"description": "Syntax support for the Haskell programming language.",
-	"version": "2.2.0",
+	"version": "2.2.1",
     "publisher": "justusadam",
 	"engines": {
 		"vscode": "^0.10.0"
@@ -26,8 +26,7 @@
         "email": "dev@justus.science"
     },
     "categories": [
-        "Languages",
-        "Snippets"
+        "Languages"
     ],
     "activationEvents": [
         "onLanguage:haskell"
@@ -64,10 +63,6 @@
             "language": "literate haskell",
             "scopeName": "text.tex.latex.haskell",
             "path": "./syntaxes/literateHaskell.tmLanguage"
-        }],
-        "snippets": [{
-            "language": "haskell",
-            "path": "./snippets/haskell.json"
         }]
     },
     "scripts": {


### PR DESCRIPTION
This PR simply fixes an ENOENT error that gets thrown on extension activation caused by the package.json file still referencing the snippets file that was deleted on the previous update.
