### PR TITLE
Comments and custom-setup section support in .cabal files

### DIFF
--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -128,6 +128,12 @@
             <key>match</key>
             <string>^[ \t]*(if|else)</string>
         </dict>
+        <dict>
+            <key>name</key>
+            <string>comment.line.double-dash</string>
+            <key>match</key>
+            <string>^\s*--.*$</string>
+        </dict>
     </array>
     <key>scopeName</key>
     <string>source.cabal</string>

--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -69,6 +69,7 @@
                 | type
                 | test-module
                 | description
+                | setup-depends
                 ):
             </string>
         </dict>
@@ -94,7 +95,10 @@
             <key>name</key>
             <string>entity.name.section.cabal</string>
             <key>match</key>
-            <string>^(?i)library$</string>
+            <string>^(?ix:
+                ( library
+                | custom-setup
+                ))$</string>
         </dict>
         <dict>
             <key>match</key>


### PR DESCRIPTION
Support for `-- line comments` and custom setup declarations like this

    custom-setup
      setup-depends:  base >= 4.7 && < 5
                    , Cabal
                    , directory
                    , filepath
                    , process