### PR TITLE
Update syntax for numeric literals

### DIFF
--- a/syntaxes/haskell.tmLanguage
+++ b/syntaxes/haskell.tmLanguage
@@ -339,15 +339,15 @@
 		</dict>
 		<dict>
 			<key>comment</key>
-			<string>Floats are always decimal</string>
+			<string>Floats are decimal or hexadecimal</string>
 			<key>match</key>
-			<string>\b([0-9]+\.[0-9]+([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)\b</string>
+			<string>\b([0-9](_*[0-9])*\.[0-9](_*[0-9])*(_*[eE][-+]?[0-9](_*[0-9])*)?|[0-9](_*[0-9])*_*[eE][-+]?[0-9](_*[0-9])*|0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][-+]?[0-9](_*[0-9])*)?|0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*_*[pP][-+]?[0-9](_*[0-9])*)\b</string>
 			<key>name</key>
 			<string>constant.numeric.float.haskell</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b([0-9]+|0([xX][0-9a-fA-F]+|[oO][0-7]+))\b</string>
+			<string>\b([0-9](_*[0-9])*|0([xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*|[oO]_*[0-7](_*[0-7])*|[bB]_*[01](_*[01])*))\b</string>
 			<key>name</key>
 			<string>constant.numeric.haskell</string>
 		</dict>


### PR DESCRIPTION
Could you please update this for syntax highlighting of numeric literals?

This patch implemented Haskell/GHC's newly accepted proposal for numeric literals. (I'm author of the proposal.)
  * https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0009-numeric-underscores.rst#new-syntax-this-proposal

I visually verified this patch with a test file.
  * https://github.com/takenobu-hs/ghc/blob/squashed-numeric-underscores/testsuite/tests/parser/should_run/NumericUnderscores0.hs


If you need more speed than accuracy, I will send the following fast (but approximate) pattern match version instead.
  * https://github.com/JustusAdam/language-haskell/compare/master...takenobu-hs:patch-numeric-literal-fast

Regards,
Takenobu
