### PR TITLE
Support for Markdown code fence (haskell, hs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,16 @@
                 "language": "literate haskell",
                 "scopeName": "text.tex.latex.haskell",
                 "path": "./syntaxes/literateHaskell.tmLanguage"
+            },
+            {
+                "scopeName": "markdown.haskell.codeblock",
+                "path": "./syntaxes/codeblock-haskell.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.haskell": "haskell"
+                }
             }
         ]
     },

--- a/syntaxes/codeblock-haskell.json
+++ b/syntaxes/codeblock-haskell.json
@@ -8,7 +8,7 @@
     ],
     "repository": {
         "haskell-code-block": {
-            "begin": "haskell(\\s+[^`~]*)?$",
+            "begin": "(haskell|hs)(\\s+[^`~]*)?$",
             "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
             "patterns": [
                 {

--- a/syntaxes/codeblock-haskell.json
+++ b/syntaxes/codeblock-haskell.json
@@ -1,0 +1,28 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:markup.fenced_code.block.markdown",
+    "patterns": [
+        {
+            "include": "#haskell-code-block"
+        }
+    ],
+    "repository": {
+        "haskell-code-block": {
+            "begin": "haskell(\\s+[^`~]*)?$",
+            "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.haskell",
+                    "patterns": [
+                        {
+                            "include": "source.haskell"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "markdown.haskell.codeblock"
+}


### PR DESCRIPTION
Partly addresses #48 but does not close it (still need `lhs`, `cabal` support).