### PR TITLE
Markdown support for literate haskell and cabal

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,26 @@
                 "embeddedLanguages": {
                     "meta.embedded.block.haskell": "haskell"
                 }
+            },
+            {
+                "scopeName": "markdown.lhaskell.codeblock",
+                "path": "./syntaxes/codeblock-literate-haskell.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.lhaskell": "lhaskell"
+                }
+            },
+            {
+                "scopeName": "markdown.cabal.codeblock",
+                "path": "./syntaxes/codeblock-cabal.json",
+                "injectTo": [
+                    "text.html.markdown"
+                ],
+                "embeddedLanguages": {
+                    "meta.embedded.block.cabal": "cabal"
+                }
             }
         ]
     },

--- a/syntaxes/codeblock-cabal.json
+++ b/syntaxes/codeblock-cabal.json
@@ -3,26 +3,26 @@
     "injectionSelector": "L:markup.fenced_code.block.markdown",
     "patterns": [
         {
-            "include": "#haskell-code-block"
+            "include": "#cabal-code-block"
         }
     ],
     "repository": {
-        "haskell-code-block": {
-            "begin": "\\b(haskell|hs)\\b(\\s+[^`~]*)?$",
+        "cabal-code-block": {
+            "begin": "\\b(cabal)\\b(\\s+[^`~]*)?$",
             "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
             "patterns": [
                 {
                     "begin": "(^|\\G)(\\s*)(.*)",
                     "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-                    "contentName": "meta.embedded.block.haskell",
+                    "contentName": "meta.embedded.block.cabal",
                     "patterns": [
                         {
-                            "include": "source.haskell"
+                            "include": "source.cabal"
                         }
                     ]
                 }
             ]
         }
     },
-    "scopeName": "markdown.haskell.codeblock"
+    "scopeName": "markdown.cabal.codeblock"
 }

--- a/syntaxes/codeblock-literate-haskell.json
+++ b/syntaxes/codeblock-literate-haskell.json
@@ -3,26 +3,26 @@
     "injectionSelector": "L:markup.fenced_code.block.markdown",
     "patterns": [
         {
-            "include": "#haskell-code-block"
+            "include": "#lhaskell-code-block"
         }
     ],
     "repository": {
-        "haskell-code-block": {
-            "begin": "\\b(haskell|hs)\\b(\\s+[^`~]*)?$",
+        "lhaskell-code-block": {
+            "begin": "\\b(literate-haskell|lhaskell|lhs)\\b(\\s+[^`~]*)?$",
             "end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
             "patterns": [
                 {
                     "begin": "(^|\\G)(\\s*)(.*)",
                     "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-                    "contentName": "meta.embedded.block.haskell",
+                    "contentName": "meta.embedded.block.lhaskell",
                     "patterns": [
                         {
-                            "include": "source.haskell"
+                            "include": "text.tex.latex.haskell"
                         }
                     ]
                 }
             ]
         }
     },
-    "scopeName": "markdown.haskell.codeblock"
+    "scopeName": "markdown.lhaskell.codeblock"
 }


### PR DESCRIPTION
Closes #48.

In addition to #55, which added markdown code fence support for `hs` and `lhs`, this PR:

- adds support for Literate Haskell using `literate-haskell`, `lhaskell`, and `lhs`
- adds support for Cabal using `cabal`
- makes support stricter by adding word boundaries `\b` to the regex for matching languages

One thing this PR does _not_ do is add any language to the README advertising or documenting this support. I don't know that it's necessary – this is a naturally discoverable, even expected, feature. I leave it up to you to decide how or if you want to incorporate that.