### PR TITLE
make capitalized Cabal default over lowercase in lang list

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
             {
                 "id": "cabal",
                 "aliases": [
-                    "cabal",
-                    "Cabal"
+                    "Cabal",
+                    "cabal"
                 ],
                 "extensions": [
                     ".cabal"


### PR DESCRIPTION
VSC uses the first language in the aliases list to populate the languages list. This PR simply puts the capitalized `Cabal` first, so it appears in the correct alphabetical position in the languages list, among all the other capitalized languages.