### PR TITLE
Switch to json versions of syntax files

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,17 +86,17 @@
             {
                 "language": "haskell",
                 "scopeName": "source.haskell",
-                "path": "./syntaxes/haskell.tmLanguage"
+                "path": "./syntaxes/haskell.tmLanguage.json"
             },
             {
                 "language": "cabal",
                 "scopeName": "source.cabal",
-                "path": "./syntaxes/cabal.tmLanguage"
+                "path": "./syntaxes/cabal.tmLanguage.json"
             },
             {
                 "language": "literate haskell",
                 "scopeName": "text.tex.latex.haskell",
-                "path": "./syntaxes/literateHaskell.tmLanguage"
+                "path": "./syntaxes/literateHaskell.tmLanguage.json"
             },
             {
                 "scopeName": "markdown.haskell.codeblock",

--- a/syntaxes/cabal.tmLanguage.json
+++ b/syntaxes/cabal.tmLanguage.json
@@ -1,0 +1,53 @@
+{
+  "fileTypes": [
+    "cabal"
+  ],
+  "name": "Cabal",
+  "patterns": [
+    {
+      "name": "keyword.other.cabal",
+      "match": "(?ix)(\\n|^)\n                ( name\n                | version\n                | cabal-version\n                | build-type\n                | license(-file)?\n                | copyright\n                | author\n                | maintainer\n                | stability\n                | homepage\n                | bug-reports\n                | package-url\n                | synopsis\n                | data-(files|dir)\n                | description\n                | category\n                | extra-(source|doc|tmp)-files\n                ):\n            "
+    },
+    {
+      "name": "keyword.other.cabal",
+      "match": "(?ix)^[ \\t]+\n                ( build-depends\n                | other-modules\n                | hs-source-dirs\n                | ((other|default)-)?extensions\n                | build-tools\n                | buildable\n                | ghc(-(prof|shared))?-options\n                | (install-)?includes\n                | include-dirs\n                | (c|js)-sources\n                | extra(-ghci)?-libraries\n                | extra-lib-dirs\n                | (cc|cpp|ld)-options\n                | pkgconfig-depends\n                | default-language\n                | frameworks\n                | default\n                | manual\n                | location\n                | branch\n                | tag\n                | subdir\n                | tested-with\n                | exposed(-modules)?\n                | reexported-modules\n                | main-is\n                | type\n                | test-module\n                | description\n                | setup-depends\n                ):\n            "
+    },
+    {
+      "name": "keyword.operator.cabal",
+      "match": "(==|>=|<=|<|>|\\|\\||&&|!)"
+    },
+    {
+      "name": "constant.numeric.cabal",
+      "match": "(?<=[^\\w])\\d+(\\.\\d+)*(\\.\\*)?"
+    },
+    {
+      "name": "markup.underline.link.cabal",
+      "match": "\\w+:/(/[\\w._\\-\\d%])+(\\?[\\w.+_\\-\\d%]+)(&[\\w._+\\-\\d%]+)*"
+    },
+    {
+      "name": "entity.name.section.cabal",
+      "match": "^(?ix:\n                ( library\n                | custom-setup\n                ))$"
+    },
+    {
+      "match": "^(?ix:\n                ( executable\n                | flag\n                | test-suite\n                | source-repository\n                ))( |\\t)+([\\w\\-_]+)$",
+      "captures": {
+        "1": {
+          "name": "entity.name.section.cabal"
+        },
+        "3": {
+          "name": "entity.name.function.cabal"
+        }
+      }
+    },
+    {
+      "name": "keyword.control.cabal",
+      "match": "^[ \\t]*(if|else)"
+    },
+    {
+      "name": "comment.line.double-dash",
+      "match": "^\\s*--.*$"
+    }
+  ],
+  "scopeName": "source.cabal",
+  "uuid": "5eb56f02-df11-40b2-b6d5-fa444522416c"
+}

--- a/syntaxes/haskell.tmLanguage.json
+++ b/syntaxes/haskell.tmLanguage.json
@@ -1,0 +1,588 @@
+{
+  "fileTypes": [
+    "hs"
+  ],
+  "keyEquivalent": "^~H",
+  "name": "Haskell",
+  "patterns": [
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.entity.haskell"
+        },
+        "2": {
+          "name": "punctuation.definition.entity.haskell"
+        }
+      },
+      "comment": "In case this regex seems unusual for an infix operator, note that Haskell allows any ordinary function application (elem 4 [1..10]) to be rewritten as an infix expression (4 `elem` [1..10]).",
+      "match": "(`)([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\.)*[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*(`)",
+      "name": "keyword.operator.function.infix.haskell"
+    },
+    {
+      "match": "\\(\\s*\\)",
+      "name": "constant.language.unit.haskell"
+    },
+    {
+      "match": "\\[\\s*\\]",
+      "name": "constant.language.empty-list.haskell"
+    },
+    {
+      "begin": "\\b(module)(\\b(?!'))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "end": "\\b(where)(\\b(?!'))",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "name": "meta.declaration.module.haskell",
+      "patterns": [
+        {
+          "include": "#module_name"
+        },
+        {
+          "include": "#module_exports"
+        },
+        {
+          "match": "[a-z]+",
+          "name": "invalid"
+        }
+      ]
+    },
+    {
+      "begin": "\\b(class)(\\b(?!'))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "end": "\\b(where)(\\b(?!'))",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "name": "meta.declaration.class.haskell",
+      "patterns": [
+        {
+          "include": "#type_signature"
+        }
+      ]
+    },
+    {
+      "match": "(?x)\n\t\t\t\t\\b(data|newtype)\n\t\t\t\t\\s+\n\t\t\t\t([\\p{Lu}\\p{Lt}][\\w\\p{Nd}_']*)\n\t\t\t\t((?:\\s+[\\p{Ll}][\\w\\p{Nd}_']*)*?)\n\t\t\t\t\\s+\n\t\t\t\t(where(?:\\b(?!'))|=|$)\n\t\t\t",
+      "captures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        },
+        "2": {
+          "name": "storage.type.haskell"
+        },
+        "3": {
+          "patterns": [
+            {
+              "match": "'*[\\p{Ll}][\\w\\p{Nd}_']*",
+              "name": "variable.other.generic-type.haskell"
+            }
+          ]
+        },
+        "4": {
+          "name": "keyword.other.haskell"
+        }
+      }
+    },
+    {
+      "match": "(?x)\n\t\t\t\t\\b(type)\n\t\t\t\t\\s+\n\t\t\t\t([^=]*)\n\t\t\t\t(?:\n\t\t\t\t\t\\s+\n\t\t\t\t\t(=)\n\t\t\t\t\t(.*)\n\t\t\t\t)?\\s*$\n\t\t\t",
+      "captures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        },
+        "2": {
+          "patterns": [
+            {
+              "include": "#type_signature"
+            }
+          ]
+        },
+        "3": {
+          "name": "keyword.other.haskell"
+        },
+        "4": {
+          "patterns": [
+            {
+              "include": "#type_signature"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "begin": "\\b(instance)(\\b(?!'))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "end": "\\b(where)(\\b(?!'))|$",
+      "endCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "name": "meta.declaration.instance.haskell",
+      "patterns": [
+        {
+          "include": "#type_signature"
+        }
+      ]
+    },
+    {
+      "begin": "\\b(import)(\\b(?!'))",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "end": "($|;|(?=--))",
+      "name": "meta.import.haskell",
+      "patterns": [
+        {
+          "match": "(qualified|as|hiding)",
+          "name": "keyword.other.haskell"
+        },
+        {
+          "include": "#module_name"
+        },
+        {
+          "include": "#module_exports"
+        }
+      ]
+    },
+    {
+      "begin": "(deriving)\\s*\\(",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        }
+      },
+      "end": "\\)",
+      "name": "meta.deriving.haskell",
+      "patterns": [
+        {
+          "include": "#derivings"
+        }
+      ]
+    },
+    {
+      "match": "(deriving)\\s+([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)",
+      "captures": {
+        "1": {
+          "name": "keyword.other.haskell"
+        },
+        "2": {
+          "name": "entity.other.inherited-class.haskell"
+        }
+      },
+      "name": "meta.deriving.haskell"
+    },
+    {
+      "match": "(?x)\\b\n\t\t\t( deriving\n\t\t\t| where\n\t\t\t| type([\\t ]+(family|role))\n\t\t\t| let\n\t\t\t| in\n\t\t\t| default\n\t\t\t| rec\n\t\t\t)(\\b(?!'))\n\t\t\t",
+      "name": "keyword.other.haskell"
+    },
+    {
+      "match": "\\binfix[lr]?(\\b(?!'))",
+      "name": "keyword.operator.haskell"
+    },
+    {
+      "match": "\\b(m?do|if|then|else|case|of)(\\b(?!'))",
+      "name": "keyword.control.haskell"
+    },
+    {
+      "include": "#numeric_literals"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.preprocessor.c"
+        }
+      },
+      "comment": "In addition to Haskell's \"native\" syntax, GHC permits the C preprocessor to be run on a source file.",
+      "match": "^\\s*(#)\\s*\\w+",
+      "name": "meta.preprocessor.c"
+    },
+    {
+      "include": "#pragma"
+    },
+    {
+      "include": "#string_literal"
+    },
+    {
+      "captures": {
+        "1": {
+          "name": "punctuation.definition.string.begin.haskell"
+        },
+        "2": {
+          "name": "constant.character.escape.haskell"
+        },
+        "3": {
+          "name": "constant.character.escape.octal.haskell"
+        },
+        "4": {
+          "name": "constant.character.escape.hexadecimal.haskell"
+        },
+        "5": {
+          "name": "constant.character.escape.control.haskell"
+        },
+        "6": {
+          "name": "punctuation.definition.string.end.haskell"
+        }
+      },
+      "match": "(?x)\n\t\t\t(')\n\t\t\t(?:\n\t\t\t\t[\\ -\\[\\]-~]\t\t\t\t\t\t\t\t# Basic Char\n\t\t\t  | (\\\\(?:NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE\n\t\t\t\t\t|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS\n\t\t\t\t\t|US|SP|DEL|[abfnrtv\\\\\\\"'\\&]))\t\t# Escapes\n\t\t\t  | (\\\\o[0-7]+)\t\t\t\t\t\t\t\t# Octal Escapes\n\t\t\t  | (\\\\x[0-9A-Fa-f]+)\t\t\t\t\t\t# Hexadecimal Escapes\n\t\t\t  | (\\^[A-Z@\\[\\]\\\\\\^_])\t\t\t\t\t\t# Control Chars\n\t\t\t)\n\t\t\t(')\n\t\t\t",
+      "name": "string.quoted.single.haskell"
+    },
+    {
+      "begin": "(?x)^(\\s*)\n                (?<fn>\n                  (?:\n                    [\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']* |\n                    \\(\n                      (?!--+\\))\n                      (?:\n                        (?![(),;\\[\\]`{}_\"'])[\\p{S}\\p{P}]\n                      )+\n                    \\)\n                  )\n                  (?:\\s*,\\s*\\g<fn>)?\n                )\n                \\s*(::|∷)",
+      "beginCaptures": {
+        "2": {
+          "patterns": [
+            {
+              "match": "[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+              "name": "entity.name.function.haskell"
+            },
+            {
+              "include": "#infix_op"
+            }
+          ]
+        },
+        "3": {
+          "name": "keyword.other.double-colon.haskell"
+        }
+      },
+      "name": "meta.function.type-declaration.haskell",
+      "patterns": [
+        {
+          "include": "#type_signature"
+        }
+      ],
+      "end": "(?=(<\\-)|(^(\\1)?[^\\s]|}))"
+    },
+    {
+      "include": "#data_constructor"
+    },
+    {
+      "include": "#comments"
+    },
+    {
+      "include": "#infix_op"
+    },
+    {
+      "begin": "(::|∷)",
+      "beginCaptures": {
+        "1": {
+          "name": "keyword.other.double-colon.haskell"
+        }
+      },
+      "end": "(?=\\)|$|,|}|\\b(in|then|else|of)\\b(?!')|(:?<\\-))",
+      "patterns": [
+        {
+          "include": "#type_signature"
+        }
+      ],
+      "name": "meta.type-declaration.haskell"
+    },
+    {
+      "comment": "In case this regex seems overly general, note that Haskell permits the definition of new operators which can be nearly any string of punctuation characters, such as $%^&*.",
+      "match": "[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+",
+      "name": "keyword.operator.haskell"
+    },
+    {
+      "match": ",",
+      "name": "punctuation.separator.comma.haskell"
+    }
+  ],
+  "repository": {
+    "block_comment": {
+      "applyEndPatternLast": 1,
+      "begin": "\\{-(?!#)",
+      "captures": {
+        "0": {
+          "name": "punctuation.definition.comment.haskell"
+        }
+      },
+      "end": "-\\}",
+      "name": "comment.block.haskell",
+      "patterns": [
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "comments": {
+      "patterns": [
+        {
+          "begin": "^\\s*(--\\s+\\|)",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.haskell"
+            }
+          },
+          "end": "(?=^(?!\\s*--\\s))",
+          "name": "comment.block.documentation.haskell"
+        },
+        {
+          "applyEndPatternLast": 1,
+          "begin": "\\{-\\|",
+          "captures": {
+            "0": {
+              "name": "punctuation.definition.comment.haskell"
+            }
+          },
+          "end": "-\\}",
+          "name": "comment.block.documentation.haskell",
+          "patterns": [
+            {
+              "include": "#block_comment"
+            }
+          ]
+        },
+        {
+          "begin": "(^[ \\t]+)?(?=--+(?![\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]))",
+          "beginCaptures": {
+            "1": {
+              "name": "punctuation.whitespace.comment.leading.haskell"
+            }
+          },
+          "comment": "Operators may begin with '--' as long as they are not entirely composed of '-' characters. This means comments can't be immediately followed by an allowable operator character.",
+          "end": "(?!\\G)",
+          "patterns": [
+            {
+              "begin": "--",
+              "beginCaptures": {
+                "0": {
+                  "name": "punctuation.definition.comment.haskell"
+                }
+              },
+              "end": "\\n",
+              "name": "comment.line.double-dash.haskell"
+            }
+          ]
+        },
+        {
+          "include": "#block_comment"
+        }
+      ]
+    },
+    "derivings": {
+      "patterns": [
+        {
+          "match": "\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+          "name": "entity.other.inherited-class.haskell"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            {
+              "include": "#derivings"
+            }
+          ]
+        }
+      ]
+    },
+    "infix_op": {
+      "comment": "An operator cannot be composed entirely of '-' characters; instead, it should be matched as a comment.",
+      "match": "(\\((?!--+\\))[\\p{S}\\p{P}&&[^(),;\\[\\]`{}_\"']]+\\)|\\(,+\\))",
+      "name": "entity.name.function.infix.haskell"
+    },
+    "module_exports": {
+      "begin": "\\(",
+      "end": "\\)",
+      "name": "meta.declaration.exports.haskell",
+      "patterns": [
+        {
+          "match": "\\b[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+          "name": "entity.name.function.haskell"
+        },
+        {
+          "match": "\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+          "name": "storage.type.haskell"
+        },
+        {
+          "match": ",",
+          "name": "punctuation.separator.comma.haskell"
+        },
+        {
+          "include": "#infix_op"
+        },
+        {
+          "comment": "So named because I don't know what to call this.",
+          "match": "\\(.*?\\)",
+          "name": "meta.other.unknown.haskell"
+        },
+        {
+          "include": "#comments"
+        }
+      ]
+    },
+    "module_name": {
+      "match": "(?<conid>[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*(\\.\\g<conid>)?)",
+      "name": "support.other.module.haskell"
+    },
+    "pragma": {
+      "begin": "\\{-#",
+      "end": "#-\\}",
+      "name": "meta.preprocessor.haskell",
+      "patterns": [
+        {
+          "match": "\\b(LANGUAGE|OPTIONS_GHC|INCLUDE|WARNING|DEPRECATED|MINIMAL|UNPACK|NOUNPACK|SOURCE|OVERLAPPING|OVERLAPPABLE|OVERLAPS|INCOHERENT|INLINE|NOINLINE|INLINABLE|CONLIKE|LINE|RULES|SPECIALIZE|SPECIALISE)\\b",
+          "name": "keyword.other.preprocessor.haskell"
+        }
+      ]
+    },
+    "data_constructor": {
+      "match": "\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*\\b",
+      "name": "constant.other.haskell"
+    },
+    "type_signature": {
+      "patterns": [
+        {
+          "match": "\\(\\s*\\)",
+          "name": "support.constant.unit.haskell"
+        },
+        {
+          "begin": "\\(",
+          "end": "\\)",
+          "patterns": [
+            {
+              "match": ","
+            },
+            {
+              "include": "#type_signature"
+            }
+          ]
+        },
+        {
+          "match": "\\(\\s*([\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\\s+([\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*)\\)\\s*(=>|⇒)",
+          "captures": {
+            "1": {
+              "name": "entity.other.inherited-class.haskell"
+            },
+            "2": {
+              "name": "variable.other.generic-type.haskell"
+            },
+            "3": {
+              "name": "keyword.other.big-arrow.haskell"
+            }
+          },
+          "name": "meta.class-constraint.haskell"
+        },
+        {
+          "include": "#pragma"
+        },
+        {
+          "match": "->|→",
+          "name": "keyword.other.arrow.haskell"
+        },
+        {
+          "match": "\\b(forall|∀)(\\b(?!'))",
+          "name": "keyword.other.forall.haskell"
+        },
+        {
+          "match": "=>|⇒",
+          "name": "keyword.other.big-arrow.haskell"
+        },
+        {
+          "match": "\\b[\\p{Ll}_][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+          "name": "variable.other.generic-type.haskell"
+        },
+        {
+          "match": "\\b[\\p{Lu}\\p{Lt}][\\p{Ll}_\\p{Lu}\\p{Lt}\\p{Nd}']*",
+          "name": "storage.type.haskell"
+        },
+        {
+          "include": "#comments"
+        },
+        {
+          "include": "#string_literal"
+        },
+        {
+          "include": "#integer_literal"
+        }
+      ]
+    },
+    "string_literal": {
+      "begin": "\"",
+      "beginCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.begin.haskell"
+        }
+      },
+      "end": "\"",
+      "endCaptures": {
+        "0": {
+          "name": "punctuation.definition.string.end.haskell"
+        }
+      },
+      "name": "string.quoted.double.haskell",
+      "patterns": [
+        {
+          "match": "\\\\(NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC1|DC2|DC3|DC4|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL|[abfnrtv\\\\\\\"'\\&])",
+          "name": "constant.character.escape.haskell"
+        },
+        {
+          "match": "\\\\o[0-7]+|\\\\x[0-9A-Fa-f]+|\\\\[0-9]+",
+          "name": "constant.character.escape.octal.haskell"
+        },
+        {
+          "match": "\\\\\\^[A-Z@\\[\\]\\\\\\^_]",
+          "name": "constant.character.escape.control.haskell"
+        },
+        {
+          "begin": "\\\\\\s",
+          "beginCaptures": {
+            "0": {
+              "name": "constant.character.escape.begin.haskell"
+            }
+          },
+          "end": "\\\\",
+          "endCaptures": {
+            "0": {
+              "name": "constant.character.escape.end.haskell"
+            }
+          },
+          "patterns": [
+            {
+              "match": "\\S+",
+              "name": "invalid.illegal.character-not-allowed-here.haskell"
+            }
+          ]
+        }
+      ]
+    },
+    "integer_literals": {
+      "comment": "Floats are decimal or hexadecimal",
+      "match": "\\b([0-9](_*[0-9])*\\.[0-9](_*[0-9])*(_*[eE][-+]?[0-9](_*[0-9])*)?|[0-9](_*[0-9])*_*[eE][-+]?[0-9](_*[0-9])*|0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*\\.[0-9a-fA-F](_*[0-9a-fA-F])*(_*[pP][-+]?[0-9](_*[0-9])*)?|0[xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*_*[pP][-+]?[0-9](_*[0-9])*)\\b",
+      "name": "constant.numeric.float.haskell"
+    },
+    "float_literals": {
+      "match": "\\b([0-9](_*[0-9])*|0([xX]_*[0-9a-fA-F](_*[0-9a-fA-F])*|[oO]_*[0-7](_*[0-7])*|[bB]_*[01](_*[01])*))\\b",
+      "name": "constant.numeric.haskell"
+    },
+    "numeric_literals": {
+      "patterns": [
+        {
+          "include": "#integer_literals"
+        },
+        {
+          "include": "#float_literals"
+        }
+      ]
+    }
+  },
+  "scopeName": "source.haskell",
+  "uuid": "5C034675-1F6D-497E-8073-369D37E2FD7D"
+}

--- a/syntaxes/literateHaskell.tmLanguage.json
+++ b/syntaxes/literateHaskell.tmLanguage.json
@@ -1,0 +1,56 @@
+{
+  "fileTypes": [
+    "lhs"
+  ],
+  "keyEquivalent": "^~H",
+  "name": "Literate Haskell",
+  "patterns": [
+    {
+      "begin": "^((\\\\)begin)({)code(})(\\s*\\n)?",
+      "captures": {
+        "1": {
+          "name": "support.function.be.latex"
+        },
+        "2": {
+          "name": "punctuation.definition.function.latex"
+        },
+        "3": {
+          "name": "punctuation.definition.arguments.begin.latex"
+        },
+        "4": {
+          "name": "punctuation.definition.arguments.end.latex"
+        }
+      },
+      "contentName": "source.haskell.embedded.latex",
+      "end": "^((\\\\)end)({)code(})",
+      "name": "meta.embedded.block.haskell.latex",
+      "patterns": [
+        {
+          "include": "source.haskell"
+        }
+      ]
+    },
+    {
+      "begin": "^(> )",
+      "beginCaptures": {
+        "1": {
+          "name": "punctuation.definition.bird-track.haskell"
+        }
+      },
+      "comment": "This breaks type signature detection for now, but it's better than having no highlighting whatsoever.",
+      "contentName": "source.haskell",
+      "end": "$",
+      "name": "meta.embedded.haskell",
+      "patterns": [
+        {
+          "include": "source.haskell"
+        }
+      ]
+    },
+    {
+      "include": "text.tex.latex"
+    }
+  ],
+  "scopeName": "text.tex.latex.haskell",
+  "uuid": "439807F5-7129-487D-B5DC-95D5272B43DD"
+}


### PR DESCRIPTION
Used TextMate VS code extension (https://marketplace.visualstudio.com/items?itemName=Togusa09.tmlanguage) to produce json versions of the plist format tmLanguage files. Examined the test .hs files - seems to have worked.