### PR TITLE
Add highlighting for backpack signature files

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "language-haskell",
     "displayName": "Haskell Syntax Highlighting",
     "description": "Syntax support for the Haskell programming language.",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "publisher": "justusadam",
     "engines": {
         "vscode": "^0.10.0"
@@ -29,7 +29,7 @@
         "email": "dev@justus.science"
     },
     "categories": [
-        "Languages"
+        "Programming Languages"
     ],
     "activationEvents": [
         "onLanguage:haskell"
@@ -55,6 +55,7 @@
                     "haskell"
                 ],
                 "extensions": [
+                    ".hsig",
                     ".hs"
                 ],
                 "configuration": "./haskell-configuration.json"

--- a/syntaxes/haskell.tmLanguage
+++ b/syntaxes/haskell.tmLanguage
@@ -5,6 +5,7 @@
 	<key>fileTypes</key>
 	<array>
 		<string>hs</string>
+		<string>hsig</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~H</string>
@@ -47,7 +48,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>\b(module)(\b(?!'))</string>
+			<string>\b(module|signature)(\b(?!'))</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/test/syntax-examples/backpack.hsig
+++ b/test/syntax-examples/backpack.hsig
@@ -1,0 +1,49 @@
+signature Token
+  ( Token
+  , Pair
+  , LayoutMode
+  , nested
+  , mismatch
+  , unmatchedOpening
+  , unmatchedClosing
+  , lexicalError
+  ) where
+
+import Data.Default
+import Data.Ix
+import GHC.Generics
+
+import Relative.Cat
+import Relative.Class
+import Relative.Delta
+import Relative.Located
+
+data Token
+instance Eq Token
+instance Ord Token
+instance Show Token
+instance Read Token
+instance Relative Token
+
+data Pair
+instance Eq Pair
+instance Ord Pair
+instance Show Pair
+instance Read Pair
+instance Ix Pair
+instance Enum Pair
+instance Bounded Pair
+instance Generic Pair
+
+data LayoutMode
+instance Eq LayoutMode
+instance Ord LayoutMode
+instance Show LayoutMode
+instance Read LayoutMode
+instance Default LayoutMode
+
+nested :: Located Pair -> Cat Token -> Token
+mismatch :: Located Pair -> Located Pair -> Cat Token -> Token
+unmatchedOpening :: Located Pair -> Token
+unmatchedClosing :: Located Pair -> Token
+lexicalError :: Delta -> String -> Token


### PR DESCRIPTION
This may be a hacky way to do it, but I just enabled `.hs` highlighting on `.hsig` files and made the `signature` keyword act the same as the `module` keyword. This is a bit leaky, so suggestions are appreciated, but IMO this isn't much of an issue.