### PR TITLE
Change single line comments in lhs files to %.

### DIFF
--- a/literate-haskell-configuration.json
+++ b/literate-haskell-configuration.json
@@ -1,0 +1,29 @@
+{
+    "comments": {
+        "lineComment": "%",
+        "blockComment": ["{-", "-}"]
+    },
+    "brackets": [
+       ["{", "}"],
+       ["[", "]"],
+       ["(", ")"]
+   ],
+   "autoClosingPairs": [
+       { "open": "{", "close": "}" },
+       { "open": "[", "close": "]" },
+       { "open": "(", "close": ")" },
+       { "open": "\"", "close": "\"", "notIn": ["string"] },
+       { "open": "`", "close": "`", "notIn": ["string", "comment"] }
+   ],
+   "surroundingPairs": [
+       ["{", "}"],
+       ["[", "]"],
+       ["(", ")"],
+       ["'", "'"],
+       ["\"", "\""],
+       ["`", "`"]
+   ],
+   "folding": {
+       "offSide": true
+   }
+}

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
                 "extensions": [
                     ".lhs"
                 ],
-                "configuration": "./haskell-configuration.json"
+                "configuration": "./literate-haskell-configuration.json"
             }
         ],
         "grammars": [


### PR DESCRIPTION
Implemented suggested fix for #24 

I think ideally the comments would be contextual (and perhaps configurable), but this change is a good start.