### PR TITLE
Associate stack.yaml.lock with yaml language mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,16 @@
                     ".lhs"
                 ],
                 "configuration": "./haskell-configuration.json"
+            },
+            {
+                "id": "yaml",
+                "aliases": [
+                    "YAML",
+                    "yaml"
+                ],
+                "filenames": [
+                    "stack.yaml.lock"
+                ]
             }
         ],
         "grammars": [


### PR DESCRIPTION
For current version, when running commands like `stack build`, stack will generate a `stack.yaml.lock` file, which does not match any language association in VS Code.

This PR associates `stack.yaml.lock` with `yaml` language id.