### PR TITLE
Cabal highlighting improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## unreleased
+
+- Highlight `common` stanzas in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
+- Highlight `benchmark` components in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
+- Highlight the `import` and `autogen-modules` fields in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
+
 ## 2.7.0 - 29.12.2019
 
 - Fixed the no-indent regex

--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -72,6 +72,7 @@
                 | setup-depends
                 | mixins
                 | import
+                | autogen-modules
                 ):
             </string>
         </dict>

--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -71,6 +71,7 @@
                 | description
                 | setup-depends
                 | mixins
+                | import
                 ):
             </string>
         </dict>

--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -108,6 +108,7 @@
                 | flag
                 | test-suite
                 | benchmark
+                | common
                 | source-repository
                 ))( |\t)+([\w\-_]+)$</string>
             <key>captures</key>

--- a/syntaxes/cabal.tmLanguage
+++ b/syntaxes/cabal.tmLanguage
@@ -107,6 +107,7 @@
                 ( executable
                 | flag
                 | test-suite
+                | benchmark
                 | source-repository
                 ))( |\t)+([\w\-_]+)$</string>
             <key>captures</key>


### PR DESCRIPTION
This PR updates the .cabal grammar to support `benchmark` components, `common` stanzas, and `import` & `autogen-modules` fields.