### PR TITLE
Type sig punctuation tokenization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Highlight `common` stanzas in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
 - Highlight `benchmark` components in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
 - Highlight the `import` and `autogen-modules` fields in `.cabal` files ([#105](https://github.com/JustusAdam/language-haskell/pull/105))
+- Fix an issue where operators starting with `::` were incorrectly treated as type signatures ([#106](https://github.com/JustusAdam/language-haskell/pull/106))
 
 ## 2.7.0 - 29.12.2019
 

--- a/syntaxes/haskell.tmLanguage
+++ b/syntaxes/haskell.tmLanguage
@@ -513,7 +513,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(::|∷)</string>
+			<string>(::|∷)\b</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>


### PR DESCRIPTION
This PR requires a word boundary following `::` for it to be recognized as the type signature operator. This fixes an issue where custom operators beginning with `::` were incorrectly being recognized as type signatures.