### PR TITLE
Enable highlighting for hs-boot files (fixes #117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x - unreleased
+
+- Enable highlighting for `.hs-boot` files ([#117](https://github.com/JustusAdam/language-haskell/issues/117)).
+
 ## 3.0.0 - 26.04.2020
 
 - Integrated several contributions from [@robrix](https://github.com/robrix)

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
         ],
         "extensions": [
           ".hsig",
+          "hs-boot",
           ".hs"
         ],
         "configuration": "./haskell-configuration.json"


### PR DESCRIPTION
This trivial change enables support for `hs-boot` files.    

I've looked at the results on the `hs-boot` files I have been working with, and the highlighting doesn't seem to run into any issues. Concerning the oddity

```haskell
type family ClosedFam a where ..
```
`..` uses the scope `keyword.operator.haskell`, which seems to work fine even if it perhaps isn't ideal.