### PR TITLE
Add support for deriving strategies (#72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.x.x - Unreleased
+
+- Add support for deriving strategies, and improve leniency for whitespace in deriving declarations
+  ([#72](https://github.com/JustusAdam/language-haskell/issues/72))
+
 ## 3.0.0 - 26.04.2020
 
 - Integrated several contributions from [@robrix](https://github.com/robrix)

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -238,11 +238,12 @@ patterns:
       '3': {patterns: [{include: '#type_signature'}]}
       '4': {name: keyword.other.instance.haskell}
       '5': {name: entity.other.inherited-class.haskell}
-  - match: '\b(deriving) (instance)\b(.*)$'
+  - match: '\b(deriving)\s+(?:(stock|newtype|anyclass)\s+)?(instance)\b(.*)$'
     captures:
       '1': {name: keyword.other.deriving.haskell}
-      '2': {name: keyword.other.instance.haskell}
-      '3': {patterns: [{include: '#type_signature'}]}
+      '2': {name: keyword.other.deriving.haskell}
+      '3': {name: keyword.other.instance.haskell}
+      '4': {patterns: [{include: '#type_signature'}]}
   - match: >-
       (?x)\b
         (?: (where)
@@ -384,9 +385,10 @@ repository:
       - {include: '#block_comment'}
   deriving:
     patterns:
-      - begin: '(deriving)\s*\('
+      - begin: '(deriving)(?:\s+(stock|newtype|anyclass))?\s*\('
         beginCaptures:
           '1': {name: keyword.other.deriving.haskell}
+          '2': {name: keyword.other.deriving.haskell}
         end: \)
         name: meta.deriving.haskell
         patterns:
@@ -394,14 +396,15 @@ repository:
 
       - match: |
           (?x)
-            (deriving)\s+
+            (deriving)(?:\s+(stock|newtype|anyclass))?\s+
               ([\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
               (\s+(via)\s+(.*)$)?
         captures:
-          '1': {name: keyword.other.haskell}
-          '2': {name: entity.other.inherited-class.haskell}
-          '4': {name: keyword.other.haskell}
-          '5': {patterns: [{include: '#type_signature'}]}
+          '1': {name: keyword.other.deriving.haskell}
+          '2': {name: keyword.other.deriving.haskell}
+          '3': {name: entity.other.inherited-class.haskell}
+          '5': {name: keyword.other.deriving.haskell}
+          '6': {patterns: [{include: '#type_signature'}]}
         name: meta.deriving.haskell
   derivings:
     patterns:

--- a/test/syntax-examples/test.hs
+++ b/test/syntax-examples/test.hs
@@ -31,7 +31,7 @@ module M
 
 
     deriving instance SomeClass => Eq a
-    deriving instance Ord a => Ord (Expr a)
+    deriving     instance Ord a => Ord (Expr a)
 
 
 -- Parens in export lists
@@ -345,12 +345,18 @@ class (AClass a, AnotherClass b) => Manager manager where
 
     {-# MINIMAL managerGetSession, managerSetSession | managerModifySession #-}
 
--- Deriving via
+-- Deriving via and deriving strategies
 
 deriving via (A b c) instance C a
 
 data B = B
     deriving A via B
+    deriving stock    Generic
+    deriving anyclass NFData
+
+newtype N a = MkN a
+deriving   stock instance Show ( N Int )
+deriving newtype instance Eq   ( N Int )
 
 
 -- Pattern synonyms


### PR DESCRIPTION
This adds support for the `anyclass`, `stock` and `newtype` deriving strategies.

![deriving_strategies_highlighting](https://user-images.githubusercontent.com/1297748/80322023-36549580-8822-11ea-8a22-bd8565b7a82c.png)

Also includes a minor bugfix: the extension didn't recognise a standalone derived instance if there were extra spaces, for instance:

```haskell
deriving    instance Eq D
```

That is now fixed.