### PR TITLE
Allow extra spaces between record field name and type signature (fixes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.x.x - unreleased
+
+- Fix regression: allow extra spaces between record field and type signature
+  ([#118](https://github.com/JustusAdam/language-haskell/issues/118))
+
 ## 3.0.0 - 26.04.2020
 
 - Integrated several contributions from [@robrix](https://github.com/robrix)

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -509,7 +509,7 @@ repository:
           (?x)
           ([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
           (?:\s*,\s*([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*))*
-          \s(::|∷)
+          \s+(::|∷)
         end: ',|(?=})'
         beginCaptures:
           '1': {name: variable.other.definition.field.haskell}

--- a/test/syntax-examples/test.hs
+++ b/test/syntax-examples/test.hs
@@ -221,15 +221,16 @@ then' = 0
 
 data Data = Data { foo :: Int, bar :: Int }
 data Data = Data { 
-    foo :: Int, bar :: Int 
+    foo :: Int, bar :: Int -- comment
   }
 data Data = Data { 
-    foo :: Int, 
-    bar :: Int
+    foo :: Int, -- comment1
+    bar :: Int  -- comment2
     }
 data Data = Data { 
-      foo :: Int
-    , bar :: Int
+      foos :: Int -- comment1
+    , bars :: Int -- comment2
+    , baz  :: Int -- comment3
     }
 
 -- GADT's


### PR DESCRIPTION
This fixes issue #118.

I've also updated the test file to showcase the issue from #121, which I have **not** fixed.