### PR TITLE
Add support for cabal internal libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   ([#120](https://github.com/JustusAdam/language-haskell/issues/120))
 - Added support for multiline type signatures for pattern synonyms
 - Fixed fixed multi pattern synonym type declarations ([#72](https://github.com/JustusAdam/language-haskell/issues/72))
+- Add support for cabal [internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs).
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/cabal.YAML-tmLanguage
+++ b/syntaxes/cabal.YAML-tmLanguage
@@ -51,6 +51,7 @@ patterns:
         | subdir
         | exposed(-modules)?
         | (other|virtual|autogen|reexported)-modules
+        | visibility
         | main-is
         | type
         | test-module
@@ -85,6 +86,7 @@ patterns:
         | benchmark
         | common
         | source-repository
+        | library
         | foreign-library
         )
       )( |\t)+([\w\-_]+)$

--- a/test/syntax-examples/test.cabal
+++ b/test/syntax-examples/test.cabal
@@ -3,14 +3,22 @@
 name: test-name
 author: Someone
 
+common common
+  build-depends: base
+
 library
-    build-depends: base
+    import: common
+    build-depends: template-haskell
     extra-library-flavours: test
     extra-dynamic-library-flavours: test
     autogen-includes: test.h
     virtual-modules: M
     x-my-option-1: test
 
-executable my-exec
-    build-depends: base
+library sublib
+  import: common
+  visibility: private
+  hs-source-dirs: src
 
+executable my-exec
+    build-depends: test-name, sublib


### PR DESCRIPTION
Adds support for `cabal` [internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs) and the associated [visibility](https://www.haskell.org/cabal/users-guide/developing-packages.html#pkg-field-library-visibility) field.    

Also added `common` stanza to the `cabal` test-case to demonstrate commits c8342a8 and 6a77a9f.