### PR TITLE
Adjust highlighting for deriving via and instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Added support for multiline type signatures for pattern synonyms
 - Fixed fixed multi pattern synonym type declarations ([#72](https://github.com/JustusAdam/language-haskell/issues/72))
 - Add support for cabal [internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs).
+- Allow unparenthesised `via` clauses, and highlight the derived instance code as usual.
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -185,7 +185,7 @@ patterns:
           - include: '#type_signature'
   - begin: '(\s*)(pattern)\s+(.*?)\s+(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
     beginCaptures:
-      '2': {name: keyword.other.haskell}
+      '2': {name: keyword.other.pattern.haskell}
       '3': 
         patterns:
           - include: '#comma'
@@ -196,9 +196,15 @@ patterns:
         ^(?!\1\s+\S|\s*$)    # at least one, no-further indented, non-whitespace character. I.e. a same-level declaration/implementation
     patterns:
       - include: '#type_signature'
-  - match: '^\s*((type|data)\s+(family|instance)|type\s+role|pattern)'
+  - match: '^\s*(?:(type\s+family)|(type\s+instance)|(data\s+family)|(data\s+instance)|(newtype\s+instance)|(type\s+role)|(pattern))'
     captures:
-      '1': {name: keyword.other.haskell}
+      '1': {name: keyword.other.type-family.haskell}
+      '2': {name: keyword.other.type-instance.haskell}
+      '3': {name: keyword.other.data-family.haskell}
+      '4': {name: keyword.other.data-instance.haskell}
+      '5': {name: keyword.other.newtype-instance.haskell}
+      '6': {name: keyword.other.type-role.haskell}
+      '7': {name: keyword.other.pattern.haskell}
   - begin: >-
       (?x)
         ^(\s*)\b(type)
@@ -248,17 +254,16 @@ patterns:
       - include: '#module_exports'
   - include: '#deriving'
   - match: '\b(deriving)\s+(via)\s+(.*)\s+(instance)\b\s+(.*)$'
-    name: test
     captures:
       '1': {name: keyword.other.deriving.haskell}
-      '2': {name: keyword.other.haskell}
+      '2': {name: keyword.other.via.haskell}
       '3': {patterns: [{include: '#type_signature'}]}
       '4': {name: keyword.other.instance.haskell}
-      '5': {name: entity.other.inherited-class.haskell}
+      '5': {patterns: [{include: '#type_signature'}]}
   - match: '\b(deriving)\s+(?:(stock|newtype|anyclass)\s+)?(instance)\b(.*)$'
     captures:
       '1': {name: keyword.other.deriving.haskell}
-      '2': {name: keyword.other.deriving.haskell}
+      '2': {name: keyword.other.deriving-strategy.haskell}
       '3': {name: keyword.other.instance.haskell}
       '4': {patterns: [{include: '#type_signature'}]}
   - match: >-
@@ -357,12 +362,13 @@ patterns:
       [\p{S}\p{P}&&[^(),;\[\]`{}_"']]+
     name: keyword.operator.haskell
   - include: '#comma'
-  - match: '^\s*(foreign)\s+(import|export)\s+(ccall|cplusplus|dotnet|jvm|stdcall)\b(?!'')'
+  - match: '^\s*(foreign)\s+(?:(import)|(export))\s+(ccall|cplusplus|dotnet|jvm|stdcall)\b(?!'')'
     name: meta.import.foreign.haskell
     captures:
       '1': {name: keyword.other.foreign.haskell}
-      '2': {name: keyword.other.haskell}
-      '3': {name: keyword.other.haskell}
+      '2': {name: keyword.other.import.haskell}
+      '3': {name: keyword.other.export.haskell}
+      '4': {name: keyword.other.calling-convention.haskell}
 repository:
   block_comment:
     applyEndPatternLast: 1
@@ -406,11 +412,11 @@ repository:
       - begin: '(deriving)(?:\s+(stock|newtype|anyclass))?\s*\('
         beginCaptures:
           '1': {name: keyword.other.deriving.haskell}
-          '2': {name: keyword.other.deriving.haskell}
+          '2': {name: keyword.other.deriving-strategy.haskell}
         end: \)
         name: meta.deriving.haskell
         patterns:
-          - include: '#derivings'
+          - include: '#type_signature'
 
       - match: |
           (?x)
@@ -419,20 +425,11 @@ repository:
               (\s+(via)\s+(.*)$)?
         captures:
           '1': {name: keyword.other.deriving.haskell}
-          '2': {name: keyword.other.deriving.haskell}
-          '3': {name: entity.other.inherited-class.haskell}
-          '5': {name: keyword.other.deriving.haskell}
+          '2': {name: keyword.other.deriving-strategy.haskell}
+          '3': {patterns: [{include: '#type_signature'}]}
+          '5': {name: keyword.other.via.haskell}
           '6': {patterns: [{include: '#type_signature'}]}
         name: meta.deriving.haskell
-  derivings:
-    patterns:
-      - match: >-
-          \b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*
-        name: entity.other.inherited-class.haskell
-      - begin: \(
-        end: \)
-        patterns:
-          - include: '#derivings'
   infix_op:
     comment: >
       An operator cannot be composed entirely of '-' characters; 
@@ -463,7 +460,7 @@ repository:
     patterns:
       - match: '\b(pattern)\b(?!'')'
         captures:
-          '1': {name: keyword.other.haskell}
+          '1': {name: keyword.other.pattern.haskell}
       - match: >-
           \b[\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*
         name: entity.name.function.haskell

--- a/test/test.sh
+++ b/test/test.sh
@@ -22,7 +22,6 @@ ticketsBroken=(
   "T0043b.hs"
   "T0044.hs"
   "T0072a.hs"
-  "T0072b.hs"
   "T0072c.hs"
   "T0071.hs"
   "T0073.hs"
@@ -117,6 +116,7 @@ runTests () {
         then
           fails+=("$name")
           echo -e "${RED}Fail (unexpected)${NC} $file"
+          echo $result
         else
           echo -e "${YELLOW}Fail   (expected)${NC} $file"
         fi

--- a/test/tickets/T0072a.hs
+++ b/test/tickets/T0072a.hs
@@ -2,28 +2,28 @@
 
 module Main 
     ( pattern P ) where
---    ^^^^^^^ meta.declaration.exports.haskell keyword.other.haskell
+--    ^^^^^^^ meta.declaration.exports.haskell keyword.other.pattern.haskell
 --            ^ constant.other.haskell
 
 import M ( pattern Q )
---         ^^^^^^^ meta.declaration.exports.haskell keyword.other.haskell
+--         ^^^^^^^ meta.declaration.exports.haskell keyword.other.pattern.haskell
 --                 ^ constant.other.haskell
 
 
 pattern A :: Type
--- <------- keyword.other.haskell
+-- <------- keyword.other.pattern.haskell
 --      ^ constant.other.haskell
 pattern (A b) = c
--- <------- keyword.other.haskell
+-- <------- keyword.other.pattern.haskell
 --       ^ constant.other.haskell
 
 pattern B :: A -> B
--- <------- keyword.other.haskell
+-- <------- keyword.other.pattern.haskell
 --      ^ constant.other.haskell
 --           ^    ^ storage.type.haskell
           -> C
 --           ^ storage.type.haskell
 
 pattern A, B :: Type
--- <------- keyword.other.haskell
+-- <------- keyword.other.pattern.haskell
 --      ^  ^ constant.other.haskell

--- a/test/tickets/T0072b.hs
+++ b/test/tickets/T0072b.hs
@@ -2,37 +2,48 @@
 
 deriving via (A b c) instance C a
 -- <------- keyword.other.deriving.haskell
---       ^^^ keyword.other.haskell
+--       ^^^ keyword.other.via.haskell
 --                   ^^^^^^^^ keyword.other.instance.haskell
-deriving via Integer instance C a
+--            ^               ^ storage.type.haskell
+--              ^ ^             ^ variable.other.generic-type.haskell
+
+deriving via Base a instance C ( Total a )
 -- <------- keyword.other.deriving.haskell
---       ^^^ keyword.other.haskell
---                   ^^^^^^^^ keyword.other.instance.haskell
+--       ^^^ keyword.other.via.haskell
+--                  ^^^^^^^^ keyword.other.instance.haskell
+--           ^^^^            ^   ^^^^^ storage.type.haskell
+--                ^                    ^ variable.other.generic-type.haskell
+
+deriving via '(F A, B) instance R '(A, G B)
+-- <------- keyword.other.deriving.haskell
+--       ^^^ keyword.other.via.haskell
+--                     ^^^^^^^^ keyword.other.instance.haskell
+--             ^ ^  ^           ^   ^  ^ ^ storage.type.haskell
 
 
 data B = B
     deriving A via B
 --  ^^^^^^^^ keyword.other.deriving.haskell
---             ^^^ keyword.other.deriving.haskell
+--             ^^^ keyword.other.via.haskell
 --           ^     ^ storage.type.haskell
-    deriving stock    Generic
+    deriving stock    ( Eq, Generic )
 --  ^^^^^^^^ keyword.other.deriving.haskell
---           ^^^^^ keyword.other.deriving.haskell
---                    ^^^^^^^ storage.type.haskell
+--           ^^^^^ keyword.other.deriving-strategy.haskell
+--                      ^^  ^^^^^^^ storage.type.haskell
     deriving anyclass NFData
 --  ^^^^^^^^ keyword.other.deriving.haskell
---           ^^^^^^^^ keyword.other.deriving.haskell
+--           ^^^^^^^^ keyword.other.deriving-strategy.haskell
 --                    ^^^^^^ storage.type.haskell
 
 newtype N a = MkN a
 deriving   stock instance Show ( N Int )
 -- <------- keyword.other.deriving.haskell
---         ^^^^^ keyword.other.deriving.haskell
+--         ^^^^^ keyword.other.deriving-strategy.haskell
 --               ^^^^^^^^ keyword.other.instance.haskell
 --                        ^^^^ storage.type.haskell
 deriving newtype instance Eq   ( N Int )
 -- <------- keyword.other.deriving.haskell
---       ^^^^^^^ keyword.other.deriving.haskell
+--       ^^^^^^^ keyword.other.deriving-strategy.haskell
 --               ^^^^^^^^ keyword.other.instance.haskell
 --                        ^^ storage.type.haskell
 

--- a/test/tickets/T0072c.hs
+++ b/test/tickets/T0072c.hs
@@ -1,44 +1,44 @@
 -- SYNTAX TEST "source.haskell" "Type/data families and instances"
 
 type family CTF1 a b where
---   ^^^^^^ keyword.other.haskell
+-- <----------- keyword.other.type-family.haskell
 --          ^^^^ storage.type.haskell
 --               ^ ^ ^ variable.other.generic-type.haskell
     CTF1 a b = D a
 --  ^^^^       ^ storage.type.haskell
 --       ^ ^     ^ variable.other.generic-type.haskell
 type family CTF2 (a :: k) :: B where
---   ^^^^^^ keyword.other.haskell
+-- <----------- keyword.other.type-family.haskell
 --          ^^^^             ^ storage.type.haskell
 --                ^    ^ variable.other.generic-type.haskell
 type family CTF3 (a :: A) = (r :: A) | r -> a where
---   ^^^^^^ keyword.other.haskell
+-- <----------- keyword.other.type-family.haskell
 --                ^          ^         ^    ^ variable.other.generic-type.haskell
 --                     ^          ^ storage.type.haskell
 
 type family   OTF a b
---   ^^^^^^ keyword.other.haskell
+-- <----------- keyword.other.type-family.haskell
 --            ^^^ storage.type.haskell
 --                ^ ^ variable.other.generic-type.haskell
 type instance OTF (a,a) c = (a,c)
---   ^^^^^^^^ keyword.other.haskell
+-- <------------- keyword.other.type-instance.haskell
 --            ^^^ storage.type.haskell
 --                 ^ ^  ^    ^ ^ variable.other.generic-type.haskell
 type instance
---   ^^^^^^^^ keyword.other.haskell
+-- <------------- keyword.other.type-instance.haskell
     OTF (Int, Bool) = Char
 --  ^^^  ^^^  ^^^^    ^^^^ storage.type.haskell
 
 data   family DF (x :: Bool)
---     ^^^^^^ keyword.other.haskell
+-- <------------- keyword.other.data-family.haskell
 --                ^ variable.other.generic-type.haskell
 --                     ^^^^ storage.type.haskell
-data instance DF 'True = DCTrue Int
---   ^^^^^^^^ keyword.other.haskell
+newtype instance DF 'True = DCTrue Int
+-- <---------------- keyword.other.newtype-instance.haskell
 --            ^^ storage.type.haskell
 --                       ^^^^^^ constant.other.haskell
 data instance DF 'False where
---   ^^^^^^^^ keyword.other.haskell
+-- <------------- keyword.other.data-instance.haskell
 --            ^^ storage.type.haskell
     DCFalse :: Float -> DF 'False
 --  ^^^^^^^ constant.other.haskell


### PR DESCRIPTION
The regular expression for `deriving via` insisted on the need for parentheses, but those aren't required.

I also removed the `entity.other.inherited-class.haskell` scope (which was seemingly only used for `deriving-via`) and replaced it with the `type_signature` TextMate pattern. This allows code like the following to render correctly:

```haskell
deriving via '(F A, B) instance R '(A, G B)
````

I've added that to the test file.

Demonstration:

before:
![deriving_instance_before](https://user-images.githubusercontent.com/1297748/80417449-0e266e80-88d6-11ea-875f-77f403b5b760.png)

after:
![deriving_instance_after](https://user-images.githubusercontent.com/1297748/80417451-0f579b80-88d6-11ea-85fe-dc54950c202a.png)

