### PR TITLE
Consistently highlight double colon

### DIFF
--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -581,6 +581,8 @@ repository:
           - include: '#comma'
           - include: '#type_signature'
       - include: '#integer_literals'
+      - match: '(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
+        name: keyword.operator.double-colon.haskell
       - match: '(?<=[\s())\w\d]):[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+(?=[\s()\w\d])'
         comment: Operator type
         name: keyword.operator.custom.haskell

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -343,7 +343,7 @@ patterns:
   - include: '#double_colon'
   - begin: '(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
     beginCaptures:
-      '1': {name: keyword.other.double-colon.haskell}
+      '1': {name: keyword.operator.double-colon.haskell}
     end: >-
       (?=\)|$|,|}|\b(in|then|else|of)\b(?!')|<\-)
     patterns:

--- a/test/syntax-examples/test.hs
+++ b/test/syntax-examples/test.hs
@@ -403,3 +403,8 @@ f =
 -- Pragmas in comment blocks
 
 {-  {-# PRAGMA  #-} -}
+
+-- Double colon inside type signatures
+
+colons :: forall (a :: (k :: l)). a -> (x :: a) -> k
+data X ( a :: ( x :: k ) ) :: k


### PR DESCRIPTION
The latest release changed from `keyword.other.double-colon` to `keyword.operator.double-colon` but one remaining use of `other` lingered.

I've also added back highlighting for `::` appearing inside type signatures, see test case:

```haskell
colons :: forall (a :: (k :: l)). a -> (x :: a) -> k
data X ( a :: ( x :: k ) ) :: k
```

