### PR TITLE
Add support for `newtype instance`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## x.x.x - unreleased
 
 - Enable highlighting for `.hs-boot` files ([#117](https://github.com/JustusAdam/language-haskell/issues/117)).
-- Highlighting for data families and instances ([#72](https://github.com/JustusAdam/language-haskell/issues/72)).
+- Highlighting for data families, and data/newtype instances ([#72](https://github.com/JustusAdam/language-haskell/issues/72)).
 - Fix regression: allow extra spaces between record field and type signature
   ([#118](https://github.com/JustusAdam/language-haskell/issues/118))
 - Add support for deriving strategies, and improve leniency for whitespace in deriving declarations

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -196,7 +196,7 @@ patterns:
         ^(?!\1\s+\S|\s*$)    # at least one, no-further indented, non-whitespace character. I.e. a same-level declaration/implementation
     patterns:
       - include: '#type_signature'
-  - match: '^\s*((type|data)\s+(family|instance)|type\s+role|pattern)'
+  - match: '^\s*((type|data)\s+(family|instance)|newtype\s+instance|type\s+role|pattern)'
     captures:
       '1': {name: keyword.other.haskell}
   - begin: >-

--- a/test/syntax-examples/test.hs
+++ b/test/syntax-examples/test.hs
@@ -381,9 +381,9 @@ pattern A, B :: Type
 type family TF a b where
 type instance TF (a,a) c = (a,c)
 
-data   family DF (x :: Bool)
-data instance DF 'True = DCTrue Int
-data instance DF 'False where
+data    family   DF (x :: Bool)
+newtype instance DF 'True = DCTrue Int
+data    instance DF 'False where
    DCFalse :: Float -> DF 'False
 
 -- Regression #122


### PR DESCRIPTION
I forgot that data family instances allow newtype instances. Added this option to the tests.