### PR TITLE
Highlight visible kind application, fixes to visible type application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   ([#71](https://github.com/JustusAdam/language-haskell/issues/71)).
 - Support record syntax in GADTs.
 - Address regression in LiquidHaskell highlighting ([#131](https://github.com/JustusAdam/language-haskell/issues/136)).
+- Add support for visible kind application (and miscellaneous fixes for visible type application).
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -290,33 +290,7 @@ patterns:
   - match: '\b(m?do|if|then|else|case|of)(\b(?!''))'
     name: keyword.control.haskell
   - include: '#numeric_literals'
-  - match: '(?<![\p{Ll}_\p{Lu}\p{Lt}\p{Nd}''])(@)\s*([\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']+)'
-    captures:
-      '1': {name: keyword.operator.at.haskell}
-      '2': 
-        patterns:
-          - include: '#type_variable'
-          - include: '#type_constructor'
-  - begin: '(?<![\p{Ll}_\p{Lu}\p{Lt}\p{Nd}''])(@)\s*(\()'
-    beginCaptures: 
-      '1': {name: keyword.operator.at.haskell}
-      '2': {name: punctuation.paren.haskell}
-    end: '\)'
-    endCaptures:
-      '0': {name: punctuation.paren.haskell}
-    name: meta.type-application.haskell
-    patterns:
-      - include: '#type_signature'
-  - begin: '(?<![\p{Ll}_\p{Lu}\p{Lt}\p{Nd}''])(@)\s*(\[)'
-    beginCaptures: 
-      '1': {name: keyword.operator.at.haskell}
-      '2': {name: punctuation.brace.haskell}
-    end: '\]'
-    name: meta.type-application.haskell
-    endCaptures:
-      '0': {name: punctuation.brace.haskell}
-    patterns:
-      - include: '#type_signature'
+  - include: '#type_application'
   - captures:
       '1': {name: punctuation.definition.preprocessor.c}
     comment: 'In addition to Haskell''s "native" syntax, GHC permits the C preprocessor to be run on a source file.'
@@ -579,6 +553,37 @@ repository:
           | }             # A block closed? Maybe this should also include `;`, because non-indentation based `do`
         )
         | ^(?!\1\s+\S|\s*$)    # at least one, no-further indented, non-whitespace character. I.e. a same-level declaration/implementation
+  type_application:
+    patterns:
+      - begin: '(?<=[\s,;\[\]{}"])(@)('')?(\()'
+        beginCaptures: 
+          '1': {name: keyword.operator.at.haskell}
+          '2': {name: keyword.operator.promotion.haskell}
+          '3': {name: punctuation.paren.haskell}
+        end: '\)'
+        endCaptures:
+          '0': {name: punctuation.paren.haskell}
+        name: meta.type-application.haskell
+        patterns:
+          - include: '#type_signature'
+      - begin: '(?<=[\s,;\[\]{}"])(@)('')?(\[)'
+        beginCaptures: 
+          '1': {name: keyword.operator.at.haskell}
+          '2': {name: keyword.operator.promotion.haskell}
+          '3': {name: punctuation.bracket.haskell}
+        end: '\]'
+        name: meta.type-application.haskell
+        endCaptures:
+          '0': {name: punctuation.bracket.haskell}
+        patterns:
+          - include: '#type_signature'
+      - begin: '(?<=[\s,;\[\]{}"])(@)(?=[\p{Ll}_\p{Lu}\p{Lt}\p{Nd}''])'
+        beginCaptures: 
+          '1': {name: keyword.operator.at.haskell}
+        end: '[^\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']'
+        name: meta.type-application.haskell
+        patterns:
+          - include: '#type_signature'
   type_signature:
     patterns:
       - match: '('')?\(\s*\)'
@@ -600,6 +605,7 @@ repository:
       - include: '#string_literal'
       - match: '''[^'']'''
         name: invalid
+      - include: '#type_application'
       - include: '#type_operator'
       - include: '#type_constructor'
       - begin: '('')?(\()'

--- a/test/test.sh
+++ b/test/test.sh
@@ -27,7 +27,6 @@ ticketsBroken=(
   "T0072a.hs"
   "T0072b2.hs"
   "T0072c.hs"
-  "T0073.hs"
   "T0091.hs"
   "T0121.hs"
   "T0132.hs"

--- a/test/tests/UnusualTypeApplications.hs
+++ b/test/tests/UnusualTypeApplications.hs
@@ -1,0 +1,30 @@
+-- SYNTAX TEST "source.haskell" "Unusual type applications"
+
+
+f =  g @A
+--     ^^ meta.type-application.haskell
+f = [g]@A
+--     ^^ meta.type-application.haskell
+f = {g}@A
+--     ^^ meta.type-application.haskell
+f =  g,@A
+--     ^^ meta.type-application.haskell
+f =  g;@A
+--     ^^ meta.type-application.haskell
+f = g @(!A)
+--    ^^^^^ meta.type-application.haskell
+f = g @[!A]
+--    ^^^^^ meta.type-application.haskell
+
+f =   g@A
+--     ^^ - meta.type-application.haskell
+f =   +@A
+--     ^^ - meta.type-application.haskell
+f =  g@@A
+--     ^^ - meta.type-application.haskell
+f = g @@A
+--     ^^ - meta.type-application.haskell
+f = g @!A
+--     ^^ - meta.type-application.haskell
+f = (g)@A
+--     ^^ - meta.type-application.haskell

--- a/test/tickets/T0073.hs
+++ b/test/tickets/T0073.hs
@@ -1,26 +1,26 @@
 -- SYNTAX TEST "source.haskell" "Visible type application"
 
 function = 
-    let l = [] @[Int] in
+    let l = [] @[( Int, f [ Bool ] )] in
 --             ^ meta.type-application.haskell
---               ^^^ storage.type.haskell 
+--                 ^^^ storage.type.haskell 
+--                      ^ variable.other.generic-type.haskell
     let x = "Hello" @String in
 --                  ^ meta.type-application.haskell 
 --                   ^^^^^^ storage.type.haskell
     let c@(Some pattern) = undefined in
---       ^ keyword.operator.haskell
 --       ^ - meta.type-application.haskell
 --         ^^^^ constant.other.haskell
-    let g = f @(g -> String) in
+    let g = f @( g ([]) -> String ) in
 --            ^ meta.type-application.haskell
---              ^ variable.other.generic-type.haskell
-    let h = k @_ @_ @Int
---            ^  ^ meta.type-application.haskell
+--               ^ variable.other.generic-type.haskell
+    let h = k @_ @a @Int
+--            ^  ^  ^ meta.type-application.haskell
+    let a = b @ c
+--            ^ - meta.type-application.haskell
     undefined
 
-
--- Visible kind application
-
-type family TF (a :: k) ( b :: l ) :: l where
-  TF @_ @(l :: Nat) A = B
---   ^  ^ meta.type-application.haskell
+g = f @Bool(A)
+--    ^ meta.type-application.haskell
+--     ^^^^ storage.type.haskell
+--          ^ - storage.type.haskell

--- a/test/tickets/T0073b.hs
+++ b/test/tickets/T0073b.hs
@@ -1,0 +1,4 @@
+-- SYNTAX TEST "source.haskell" "Visible kind application"
+
+type TF l = F @_ @(l :: Nat) A
+--            ^  ^ meta.type-application.haskell


### PR DESCRIPTION
Type application is now detected by: space, then `@`, then an expression of the following three forms:
  - between `(`, `)`
  - between `[`, `]`
  - a sequence of allowed characters as defined by `[\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']`

I added some tricky situations to the test case to check that it's behaving as expected, but please add more cases if you can spot other issues/potential issues.

Note that we're doing better than GitHub on this one! 😄 

Fixes test case `T0073`.