### PR TITLE
Improve support for promotion ticks (fixes #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed fixed multi pattern synonym type declarations ([#72](https://github.com/JustusAdam/language-haskell/issues/72))
 - Add support for cabal [internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs).
 - Allow unparenthesised `via` clauses, and highlight the derived instance code as usual.
+- Improve support for promotion ticks ([#136](https://github.com/JustusAdam/language-haskell/issues/136)).
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -580,9 +580,7 @@ repository:
       - include: '#integer_literals'
       - match: '(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
         name: keyword.operator.double-colon.haskell
-      - match: '(?<=[\s())\w\d]):[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+(?=[\s()\w\d])'
-        comment: Operator type
-        name: keyword.operator.custom.haskell
+      - include: '#type_operator'
       - include: '#pragma'
       - match: '->|→'
         name: keyword.operator.arrow.haskell
@@ -605,8 +603,33 @@ repository:
     match: '\b[\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*'
     name: variable.other.generic-type.haskell
   type_constructor:
-    match: '\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*(?!\.)\b'
-    name: storage.type.haskell
+    patterns:
+      # Type starting with a capital letter (with or without promotion tick)
+      - match: '(?<!'')('')?\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*(?!\.)\b'
+        name: storage.type.haskell
+        captures:
+          '1': {name: keyword.operator.promotion.haskell}
+      # Prefix form of a type operator (with or without promotion tick)
+      - match: '('')?(\()(:[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+)(\))'
+        captures:
+          '1': {name: keyword.operator.promotion.haskell}
+          '2': {name: punctuation.paren.haskell}
+          '4': {name: punctuation.paren.haskell}
+        name: storage.type.operator.prefix.haskell
+  type_operator:
+    patterns:
+      # Type operator
+      - match: '(?<=[\s())\w\d])('')?:[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+(?=[\s()\w\d])'
+        name: storage.type.operator.haskell
+        captures:
+          '1': {name: keyword.operator.promotion.haskell}
+      # Infix form
+      - match: '('')?(`)([\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']+)(`)'
+        captures:
+          '1': {name: keyword.operator.promotion.haskell}
+          '2': {name: punctuation.backtick.haskell}
+          '4': {name: punctuation.backtick.haskell}
+        name: storage.type.operator.infix.haskell
   forall:
     match: '\b(forall|∀)\b(?!'')'
     captures: 

--- a/test/test.sh
+++ b/test/test.sh
@@ -116,7 +116,7 @@ runTests () {
         then
           fails+=("$name")
           echo -e "${RED}Fail (unexpected)${NC} $file"
-          echo $result
+          echo -e $result
         else
           echo -e "${YELLOW}Fail   (expected)${NC} $file"
         fi

--- a/test/tickets/T0070.hs
+++ b/test/tickets/T0070.hs
@@ -8,6 +8,6 @@ data (:=>) a b c = D
 --                 ^ constant.other.haskell
 
 f :: a :-> b -> c :=> e
---     ^^^ keyword.operator.custom.haskell
---                ^^^ keyword.operator.custom.haskell
+--     ^^^ storage.type.operator.haskell
+--                ^^^ storage.type.operator.haskell
 

--- a/test/tickets/T0111.hs
+++ b/test/tickets/T0111.hs
@@ -11,11 +11,11 @@ type T a =
 -- Multi line type alias with infix constructors
 
 type UserApi = "users" :> Body '[JSON]
---                     ^^ keyword.operator.custom.haskell
+--                     ^^ storage.type.operator.haskell
                        :> Post '[JSON]
 --                        ^^^^ storage.type.haskell
           :<|> "users" :> Capture "userid"
---        ^^^^ keyword.operator.custom.haskell
+--        ^^^^ storage.type.operator.haskell
 --                                ^^^^^^^^ string.quoted.double.haskell
                        :> ReqBody '[JSON]
 --                        ^^^^^^^ storage.type.haskell

--- a/test/tickets/T0136.hs
+++ b/test/tickets/T0136.hs
@@ -1,0 +1,11 @@
+-- SYNTAX TEST "source.haskell" "Promotion ticks"
+
+f :: proxy ( 'CD a b ) -> proxy ( a '`CD` b )
+--            ^^ storage.type.haskell
+--                                    ^^ storage.type.operator.infix.haskell
+--           ^                      ^ keyword.operator.promotion.haskell
+
+g :: proxy ( '(:<) a b ) -> proxy ( a ':< b )
+--             ^^ storage.type.operator.prefix.haskell
+--                                     ^^ storage.type.operator.haskell
+--           ^                        ^ keyword.operator.promotion.haskell


### PR DESCRIPTION
This fixes the issues outlined in ticket #136. I've also taken the liberty of changing `keyword.operator.custom.haskell` to `storage.type.operator.haskell`, as in my opinion symbolic operators should be treated much the same as ones that start with a letter.