### PR TITLE
Allow pragmas in module declaration headers

### DIFF
--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -36,6 +36,7 @@ patterns:
     patterns:
       - include: '#module_name'
       - include: '#module_exports'
+      - include: '#pragma'
       - include: '#comments'
       - match: '[a-z]+'
         name: invalid

--- a/test/test.sh
+++ b/test/test.sh
@@ -26,7 +26,6 @@ ticketsBroken=(
   "T0071.hs"
   "T0073.hs"
   "T0091.hs"
-  "T0112.hs"
   "T0121.hs"
   "T0131.hs"
   "T0132.hs"

--- a/test/tickets/T0112.hs
+++ b/test/tickets/T0112.hs
@@ -2,7 +2,7 @@
 
 module Web.Telegram.API.Lens {-# dEPrecatED "use labels from generic-lens instead" #-}
 --                               ^^^^^^^^^^ meta.preprocessor.haskell keyword.other.preprocessor.haskell
---                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.haskell string.quoted.double.haskell
+--                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.preprocessor.haskell string.quoted.double.haskell
   where
 
 {-# dEPrecatED foo "use labels from generic-lens instead" #-}


### PR DESCRIPTION
As seen for instance [here](https://hackage.haskell.org/package/telegram-raw-api-0.1.0/docs/src/Web.Telegram.API.Lens.html), pragmas can be allowed within the module declaration header. So I've simply allowed pragmas to be parsed at that location. This fixes `T0112`.