### PR TITLE
Support record syntax in GADTs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Add support for cabal [internal libraries](https://www.haskell.org/cabal/users-guide/developing-packages.html#sublibs).
 - Allow unparenthesised `via` clauses, and highlight the derived instance code as usual.
 - Improve support for promotion ticks ([#136](https://github.com/JustusAdam/language-haskell/issues/136)).
+- Support record syntax in GADTs.
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -85,6 +85,7 @@ patterns:
             ^(?!\1\s+\S|\s*$)    # at least one, no-further indented, non-whitespace character. I.e. a same-level declaration/implementation
         patterns:
           - include: '#double_colon'
+          - include: '#record_decl'
           - include: '#type_signature'
       - begin: '(\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*)\b'
         beginCaptures:

--- a/test/test.sh
+++ b/test/test.sh
@@ -15,7 +15,6 @@ namedBroken=(
   "QualifiedInfix.hs"
 )
 ticketsBroken=(
-  "T0020b.hs"
   "T0028b.hs"
   "T0028c.hs"
   "T0039b.hs"

--- a/test/tickets/T0020b.hs
+++ b/test/tickets/T0020b.hs
@@ -5,3 +5,14 @@ data A where
 --         ^^^^^^         ^^^^^^ meta.record.definition.haskell variable.other.definition.field.haskell
 --         ^^^^^^         ^^^^^^^ - variable.other.generic-type.haskell
 --                   ^^^            ^^^ meta.record.definition.haskell storage.type.haskell
+
+data B where
+  B
+    :: { field3 :: Bool
+--       ^^^^^^ meta.record.definition.haskell variable.other.definition.field.haskell
+--       ^^^^^^^ - variable.other.generic-type.haskell
+       , field4 :: Int
+--       ^^^^^^ meta.record.definition.haskell variable.other.definition.field.haskell
+--       ^^^^^^^ - variable.other.generic-type.haskell
+       }
+    -> B


### PR DESCRIPTION
This adds record syntax for GADTs, fixing test case `T0020b`:

```haskell
data A where
    A :: { field1 :: Int, field2 :: Int } -> A

data B where
  B
    :: { field3 :: Bool
       , field4 :: Int
       }
    -> B
```

(GitHub gets this wrong it seems.)