### PR TITLE
Add type keyword to module exports

### DIFF
--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -466,6 +466,9 @@ repository:
       - match: '\b(pattern)\b(?!'')'
         captures:
           '1': {name: keyword.other.pattern.haskell}
+      - match: '\b(type)\b(?!'')'
+        captures:
+          '1': {name: keyword.other.type.haskell}
       - match: >-
           \b[\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*
         name: entity.name.function.haskell

--- a/test/test.sh
+++ b/test/test.sh
@@ -10,9 +10,13 @@ tickets=($PWD/tickets/*)
 # Arrays containing filenames of broken tests.
 namedBroken=(
   "Comments.hs"
+  "Exports.hs"
+  "Haddocks.hs"
   "InvalidClosingBlockComment.hs"
   "Keywords.hs"
+  "MultiLineTypeSignatures.hs"
   "QualifiedInfix.hs"
+  "TypeSigs.hs"
 )
 ticketsBroken=(
   "T0028b.hs"
@@ -21,6 +25,7 @@ ticketsBroken=(
   "T0043b.hs"
   "T0044.hs"
   "T0072a.hs"
+  "T0072b2.hs"
   "T0072c.hs"
   "T0071.hs"
   "T0073.hs"

--- a/test/tests/Exports.hs
+++ b/test/tests/Exports.hs
@@ -1,0 +1,31 @@
+-- SYNTAX TEST "source.haskell" "Exports"
+
+module M 
+  ( T(f,C,g)
+--  ^ storage.type.haskell
+--      ^ constant.other.haskell
+--    ^   ^ entity.name.function.haskell
+  , S(..)
+--  ^ storage.type.haskell
+  , (:->)((:>))
+--   ^^^ storage.type.haskell
+--         ^^ constant.other.haskell
+  , (:<>)(C,a,D,E)
+--   ^^^ storage.type.haskell
+--        ^   ^ ^ constant.other.haskell
+--          ^ entity.name.function.haskell
+  , A((<>), (:>>))
+--  ^ storage.type.haskell
+--     ^^    ^^^ constant.other.haskell
+  , pattern P
+--          ^ constant.other.haskell
+  , pattern (:|)
+--           ^^ constant.other.haskell
+  , type T
+--       ^ storage.type.haskell
+  , type (:-)
+--        ^^ storage.type.haskell
+  , type (<+>)
+--        ^^^ storage.type.haskell
+  )
+  where

--- a/test/tests/Haddocks.hs
+++ b/test/tests/Haddocks.hs
@@ -1,0 +1,18 @@
+-- SYNTAX TEST "source.haskell" "Haddock documentation"
+
+  -- | Doc
+--     ^^^ comment.block.documentation.haskell
+
+{-| doc
+--  ^^^ comment.block.documentation.haskell
+    doc
+--  ^^^ comment.block.documentation.haskell
+    doc -}
+--  ^^^ comment.block.documentation.haskell
+
+
+g :: a -- ^ doc
+--          ^^^ comment.block.documentation.haskell
+  -> b -- ^ doc
+--          ^^^ comment.block.documentation.haskell
+  -> c

--- a/test/tests/MultiLineTypeSignatures.hs
+++ b/test/tests/MultiLineTypeSignatures.hs
@@ -1,0 +1,28 @@
+-- SYNTAX TEST "source.haskell" "Multi-line type signatures"
+
+f :: A
+--   ^ storage.type.haskell
+  -> B
+--   ^ storage.type.haskell
+  -> C
+--   ^ storage.type.haskell
+
+f 
+  :: A -> B
+--   ^    ^ storage.type.haskell
+
+f 
+  :: forall a b
+--   ^^^^^^ keyword.other.forall.haskell
+--          ^ ^ variable.other.generic-type.haskell
+  .  C x
+--   ^ storage.type.haskell
+--     ^ variable.other.generic-type.haskell
+  => D a
+--   ^ storage.type.haskell
+--     ^ variable.other.generic-type.haskell
+  => E b
+--   ^ storage.type.haskell
+--     ^ variable.other.generic-type.haskell
+  -> G
+--   ^ storage.type.haskell

--- a/test/tests/TypeSigs.hs
+++ b/test/tests/TypeSigs.hs
@@ -1,0 +1,60 @@
+-- SYNTAX TEST "source.haskell" "Type signatures in various positions"
+
+f :: ( x :: Int ) -> Int
+-- <~~-- ^^ keyword.operator.double-colon.haskell
+--          ^^^      ^^^ storage.type.haskell
+f x = do
+--  ^ keyword.operator.eq.haskell
+  let x :: Int
+--      ^^ keyword.operator.double-colon.haskell
+--         ^^^ storage.type.haskell
+      x = 3
+--      ^ keyword.operator.eq.haskell
+  let
+    y :: Int
+--    ^^ keyword.operator.double-colon.haskell
+--       ^^^ storage.type.haskell
+    y = 3
+--    ^ keyword.operator.eq.haskell
+    z :: Int = 3
+--    ^^ keyword.operator.double-colon.haskell
+--       ^^^ storage.type.haskell
+    ( w :: Int ) = 4
+--      ^^ keyword.operator.double-colon.haskell
+--         ^^^ storage.type.haskell
+--               ^ keyword.operator.eq.haskell
+  x :: Int <- 3
+--  ^^ keyword.operator.double-colon.haskell
+--     ^^^ storage.type.haskell
+--         ^^ keyword.operator.haskell
+  ( x :: Int ) <- 4
+--    ^^ keyword.operator.double-colon.haskell
+--       ^^^ storage.type.haskell
+--             ^^ keyword.operator.haskell
+  case x :: Int of
+--       ^^ keyword.operator.double-colon.haskell
+--          ^^^ storage.type.haskell
+    ( 2 :: Int ) -> 3
+--      ^^ keyword.operator.double-colon.haskell
+--         ^^^ storage.type.haskell
+--               ^^ keyword.operator.haskell
+  where x :: Int
+--        ^^ keyword.operator.double-colon.haskell
+--           ^^^ storage.type.haskell
+        x = 3
+--        ^ keyword.operator.eq.haskell
+  where
+    y :: Int
+--    ^^ keyword.operator.double-colon.haskell
+--       ^^^ storage.type.haskell
+    y = 3
+--    ^ keyword.operator.eq.haskell
+
+type T ( x :: Int ) :: ( k :: D x )
+--         ^^       ^^     ^^ keyword.operator.double-colon.haskell
+--   ^        ^^^             ^ storage.type.haskell
+--       ^               ^      ^ variable.other.generic-type.haskell
+type T x = X :: D x
+--           ^^ keyword.operator.double-colon.haskell
+--   ^     ^    ^ storage.type.haskell
+--     ^          ^ variable.other.generic-type.haskell

--- a/test/tickets/T0072b2.hs
+++ b/test/tickets/T0072b2.hs
@@ -1,0 +1,22 @@
+-- SYNTAX TEST "source.haskell" "Deriving strategies (different lines)"
+
+data B = B deriving A via B
+--         ^^^^^^^^ keyword.other.deriving.haskell
+--                    ^^^ keyword.other.via.haskell
+--                  ^     ^ storage.type.haskell
+data B = B deriving stock    ( Eq, Generic )
+--         ^^^^^^^^ keyword.other.deriving.haskell
+--                  ^^^^^ keyword.other.deriving-strategy.haskell
+--                             ^^  ^^^^^^^ storage.type.haskell
+data B = B deriving anyclass NFData
+--         ^^^^^^^^ keyword.other.deriving.haskell
+--                  ^^^^^^^^ keyword.other.deriving-strategy.haskell
+--                           ^^^^^^ storage.type.haskell
+
+newtype StateMonad b c r = StateMonad (StateT (MyState (Something b c) b) IO r)
+    deriving (MonadState (MyState (Something b c) b), MonadIO, Monad)
+--  ^^^^^^^^ keyword.other.deriving.haskell
+      via ( State ( s, t ) r )
+--    ^^^ keyword.other.via.haskell
+--          ^^^^^ storage.type.haskell
+--                  ^  ^   ^ variable.other.generic-type.haskell


### PR DESCRIPTION
Recognises the `type` keyword in module export lists, and adds some tests (one related, others not) that don't currently pass.