### PR TITLE
Improved highlighting for symbolic operators: reserved and unreserved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Improved highlighting for module imports with unusual indentation.
 - Support for Haddock documentation heralds `*`, `^`, `$`.
 - Fix regression for comments inside record definitions ([#131](https://github.com/JustusAdam/language-haskell/issues/136))
+- Improved support for reserved symbolic operators.
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -51,9 +51,9 @@ patterns:
       (?x)
         ^(\s*)\b(?:(?:(data)\s+(instance))|(data))
         \s+
-        (
-          [\p{Lu}\p{Lt}][\w\p{Nd}_']*                   # named type
-        | \(\s*:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\s*\)   # Operator type
+        (?:
+          ([\p{Lu}\p{Lt}][\w\p{Nd}_']*)                  # named type
+        | \(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)  # Operator type
         )
         (.*)
         \b(where(?:\b(?!')))
@@ -62,10 +62,11 @@ patterns:
       '3': {name: keyword.other.instance.haskell}
       '4': {name: keyword.other.data.haskell}
       '5': {name: storage.type.haskell}
-      '6':
+      '6': {name: storage.type.operator.haskell}
+      '7':
         patterns:
           - include: '#type_signature'
-      '7': {name: keyword.other.where.haskell}
+      '8': {name: keyword.other.where.haskell}
     name: meta.declaration.type.gadt.haskell
     end: | 
       (?x)
@@ -103,20 +104,23 @@ patterns:
           - include: '#double_colon'
           - include: '#record_decl'
           - include: '#type_signature'
-      - begin: '(\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*)'
+      - begin: >-
+          (?x)
+            (\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}]*) # named constructor
+           |\(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)  # prefix operator
         beginCaptures:
           '1': {name: constant.other.haskell}
-          '2': {name: keyword.operator.double-colon.haskell}
+          '2': {name: constant.other.haskell}
         end: '$'
-        patterns: 
+        patterns:
           - include: '#type_signature'
   - begin: >-
       (?x)
         ^(\s*)\b(?:(?:(newtype)\s+(instance))|(newtype))
         \s+
-        (
-          [\p{Lu}\p{Lt}][\w\p{Nd}_']*                   # named type
-        | \(\s*:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\s*\)   # Operator type
+        (?:
+          ([\p{Lu}\p{Lt}][\w\p{Nd}_']*)                  # named type
+        | \(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)  # Operator type
         )
         ([^=]*)
         (?:(=)|$)
@@ -125,10 +129,11 @@ patterns:
       '3': {name: keyword.other.instance.haskell}
       '4': {name: keyword.other.newtype.haskell}
       '5': {name: storage.type.haskell}
-      '6':
+      '6': {name: storage.type.operator.haskell}
+      '7':
         patterns:
           - include: '#type_signature'
-      '7': {name: keyword.operator.eq.haskell}
+      '8': {name: keyword.operator.eq.haskell}
     name: meta.declaration.newtype.haskell
     end: | 
       (?x)
@@ -182,9 +187,9 @@ patterns:
       (?x)
         ^(\s*)\b(?:(?:(data)\s+(instance))|(data))
         \s+
-        (
-          [\p{Lu}\p{Lt}][\w\p{Nd}_']*                   # named type
-        | \(\s*:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\s*\)   # Operator type
+        (?:
+          ([\p{Lu}\p{Lt}][\w\p{Nd}_']*)                  # named type
+        | \(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)  # Operator type
         )
         ([^=]*)
         (?:(=)|$)
@@ -193,11 +198,12 @@ patterns:
       '3': {name: keyword.other.instance.haskell}
       '4': {name: keyword.other.data.haskell}
       '5': {name: storage.type.haskell}
-      '6':
+      '6': {name: storage.type.operator.haskell}
+      '7':
         patterns:
           - include: '#type_signature'
-      '7': {name: keyword.operator.eq.haskell}
-    end: | 
+      '8': {name: keyword.operator.eq.haskell}
+    end: |
       (?x)
          ^(?!          # It ends *unless* the *new* line is:
             \1\s+\S    # - Some haskell stuff, but more indented (continuation)
@@ -215,11 +221,19 @@ patterns:
       - include: '#existential'
       - include: '#record_decl'
       - include: '#deriving'
-      - begin: '^(\s*)(?:(\|)|(=))\s*(\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*)'
+      - begin: >-
+          (?x)
+            ^(\s*)
+              (?:(\|)|(=))\s*
+              (?:
+                 (\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
+                |\(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]*)\s*\)
+              )\s*
         beginCaptures:
           '2': {name: keyword.operator.pipe.haskell}
           '3': {name: keyword.operator.eq.haskell}
           '4': {name: constant.other.haskell}
+          '5': {name: constant.other.haskell}
         end: |
           (?x)
             (?=\||\bderiving\b)  # A deriving clause could be futher indented
@@ -236,7 +250,11 @@ patterns:
         patterns:
           - include: '#record_decl' 
           - include: '#type_signature'
-      - begin: '\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*'
+      - begin: >-
+          (?x)
+            ( (?:\b[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
+            | (?:\(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]*\))
+            )
         beginCaptures: 
           '0': {name: constant.other.haskell}
         end: '\||$'
@@ -391,11 +409,11 @@ patterns:
       '1': {name: keyword.other.where.haskell}
       '2': {name: keyword.other.let.haskell}
       '3': {name: keyword.other.in.haskell}
-      '4': {name: keyword.other.haskell}
-      '5': {name: keyword.other.haskell}
+      '4': {name: keyword.other.default.haskell}
+      '5': {name: keyword.control.haskell}
   - match: '\binfix[lr]?(\b(?!''))'
     name: keyword.operator.haskell
-  - match: '\b(m?do|if|then|else|case|of)(\b(?!''))'
+  - match: '\b(m?do|if|then|else|case|of|proc)(\b(?!''))'
     name: keyword.control.haskell
   - include: '#numeric_literals'
   - include: '#type_application'
@@ -428,15 +446,32 @@ patterns:
   - include: '#data_constructor'
   - include: '#qualifier'
   - include: '#infix_op'
-  - include: '#double_colon'
   - begin: '(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
     beginCaptures:
       '1': {name: keyword.operator.double-colon.haskell}
     end: >-
-      (?=\)|$|,|}|\b(in|then|else|of)\b(?!')|<\-)
+      (?x)
+        # End type annotation when seeing one of:
+        (?=
+          \)                          # closing parenthesis
+          |$                          # end of line
+          |,                          # comma
+          |}                          # closing bracket
+          |\b(in|then|else|of)\b(?!') # keyword
+          |                           # symbolic keyword except (->)
+          (?<![\p{S}\p{P}&&[^(),;\[\]`{}_"']])((<-)|(=)|(-<)|(-<<))([(),;\[\]`{}_"']|[^\p{S}\p{P}])
+        )
     patterns:
       - include: '#type_signature'
     name: meta.type-declaration.haskell
+  - match: '(?<![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])(?:(\\)|(<-)|(->)|(=)|(-<)|(-<<))(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])'
+    captures:
+      '1': {name: keyword.operator.lambda.haskell}
+      '2': {name: keyword.operator.arrow.left.haskell}
+      '3': {name: keyword.operator.arrow.haskell}
+      '4': {name: keyword.operator.eq.haskell}
+      '5': {name: keyword.operator.arrow.left.tail.haskell}
+      '6': {name: keyword.operator.arrow.left.tail.double.haskell}
   - match: >-
       ((?:(?<!'')('')?[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*\.)*)([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)
     comment: >
@@ -537,12 +572,16 @@ repository:
           '6': {patterns: [{include: '#type_signature'}]}
         name: meta.deriving.haskell
   infix_op:
-    comment: >
-      An operator cannot be composed entirely of '-' characters; 
-      instead, it should be matched as a comment.
-    match: >-
-      (\((?!--+\))[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\)|\(,+\))
-    name: entity.name.function.infix.haskell
+    patterns:
+      - match: '\(\s*,[\s,]*\)'
+        name: support.constant.tuple.haskell
+      - comment: >
+          An operator cannot be composed entirely of '-' characters; 
+          instead, it should be matched as a comment.
+        match: >-
+          \(\s*((?!--+\))[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)
+        captures:
+          '1': {name: entity.name.function.infix.haskell}
   module_exports:
     begin: \(
     beginCaptures:
@@ -573,7 +612,7 @@ repository:
             # Data constructor
             ([\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
             # Prefix form of symbolic constructor
-            | (\(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\))
+            | \(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)
         endCaptures:
           '1': {name: constant.other.haskell}
           '2': {name: constant.other.haskell}
@@ -587,10 +626,10 @@ repository:
             # Type name
             ([\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
             # Prefix form of type operator
-            | (\([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\))
+            | \(\s*([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)
         endCaptures:
           '1': {name: storage.type.haskell}
-          '2': {name: storage.type.operator.prefix.haskell}
+          '2': {name: storage.type.operator.haskell}
         patterns:
           - include: '#comment_like'
       - match: >-
@@ -601,8 +640,9 @@ repository:
         name: storage.type.haskell
       - include: '#infix_op'
       - include: '#comment_like'
-      - match: '\(\s*:[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+\s*\)'
-        name: storage.type.haskell
+      - match: '\(\s*(:[\p{S}\p{P}&&[^(),;\[\]`{}_"'']]+)\s*\)'
+        captures:
+          '1': {name: storage.type.haskell}
   comma:
     match: ','
     name: punctuation.separator.comma.haskell
@@ -666,7 +706,7 @@ repository:
     begin: |
       (?x)
         (?:([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)
-          |(\([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+\))
+          |\(\s*([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\)
         )
     end: ',|(?=})'
     beginCaptures:
@@ -684,16 +724,16 @@ repository:
         (?<fn>
           (?:
             [\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*
-          | \(
+          | \(\s*
               (?!--+\))
               (?:
                 (?![(),;\[\]`{}_"'])[\p{S}\p{P}]
               )+
-            \)
+            \s*\)
           )
           (?:\s*,\s*\g<fn>)?
         )
-        \s*(::|∷)
+        \s*(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']])
     beginCaptures:
       '2':
         patterns:
@@ -706,9 +746,19 @@ repository:
       - include: '#type_signature'
     end: |
       (?x)
-        (?=               # we look ahead, but we do not want to consume
-          (<\-)           # we are the left side of a `x :: Type <- expr` bind statement
-          | }             # A block closed? Maybe this should also include `;`, because non-indentation based `do`
+        (?= 
+          # we look ahead, but we do not want to consume
+
+            # are we to the left side of a symbolic keyword such as = or <- ?
+              # non-symbolic character
+              (?<![\p{S}\p{P}&&[^(),;\[\]`{}_"']])
+              # symbolic keyword except (->)
+              ((<-)|(=)|(-<)|(-<<))
+              # non-symbolic character
+              ([(),;\[\]`{}_"']|[^\p{S}\p{P}])
+
+            # A block closed? Maybe this should also include `;`, because non-indentation based `do`
+            |}
         )
         |^(?!          # It ends *unless* the *new* line is:
             \1\s+\S    # - Some haskell stuff, but more indented (continuation)
@@ -827,18 +877,18 @@ repository:
             # Optional promotion tick
               (')?
             # Opening parenthesis
-              (\()
+              (\()\s*
             # Optional qualified name
               ((?:[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*\.)*)
             # Type operator proper
               ([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)
             # Closing parenthesis
-              (\))
+              \s*(\))
         captures:
           '1': {name: keyword.operator.promotion.haskell}
           '2': {name: punctuation.paren.haskell}
           '3': {name: entity.name.namespace.haskell}
-          '4': {name: storage.type.operator.prefix.haskell }
+          '4': {name: storage.type.operator.haskell }
           '5': {name: punctuation.paren.haskell}
   type_operator:
     patterns:

--- a/test/test.sh
+++ b/test/test.sh
@@ -13,11 +13,9 @@ namedBroken=(
   "NearReserved.hs"
   "QualifiedInfix.hs"
   "ReservedInComments.hs"
-  "TypeSigs.hs"
   "TypeVsData.hs"
 )
 ticketsBroken=(
-  "T0028b.hs"
   "T0028c.hs"
   "T0039b.hs"
   "T0043b.hs"

--- a/test/tests/Arrows.hs
+++ b/test/tests/Arrows.hs
@@ -1,0 +1,9 @@
+-- SYNTAX TEST "source.haskell" "Arrow keywords"
+
+  h a b = proc (a, r) -> do rec
+--                    ^^ keyword.operator.arrow.haskell
+--        ^^^^           ^^ ^^^ keyword.control.haskell
+    (f -< (a, r)) `h` \e -> g -< ((a, e), r)
+--                    ^ keyword.operator.lambda.haskell
+--                       ^^ keyword.operator.arrow.haskell
+--     ^^                     ^^ keyword.operator.arrow.left.tail.haskell

--- a/test/tests/Exports.hs
+++ b/test/tests/Exports.hs
@@ -30,13 +30,13 @@ module M
 --       ^ storage.type.haskell
   , type (:-)
 --  ^^^^ keyword.other.type.haskell
---        ^^ storage.type.operator.prefix.haskell
+--        ^^ storage.type.operator.haskell
   , type (<+>)
 --  ^^^^ keyword.other.type.haskell
---        ^^^ storage.type.operator.prefix.haskell
+--        ^^^ storage.type.operator.haskell
   , type {- T -}
 --  ^^^^ keyword.other.type.haskell
       (<->)
---    ^^^^^ storage.type.operator.prefix.haskell
+--     ^^^ storage.type.operator.haskell
   )
   where

--- a/test/tests/Fields.hs
+++ b/test/tests/Fields.hs
@@ -26,29 +26,29 @@ fld2 :: F
 
 
 data Rec = Rec
-       { (&) :: F, -- }
---       ^^^ variable.other.definition.field.haskell
---           ^^ keyword.operator.double-colon.haskell
---              ^ storage.type.haskell
---                 ^^^^ comment.line.double-dash.haskell
+       { (& ) :: F, -- }
+--        ^ variable.other.definition.field.haskell
+--            ^^ keyword.operator.double-colon.haskell
+--               ^ storage.type.haskell
+--                  ^^^^ comment.line.double-dash.haskell
 (<>) :: F
--- <---- variable.other.definition.field.haskell
+-- <~-- variable.other.definition.field.haskell
 --   ^^ keyword.operator.double-colon.haskell
 --      ^ storage.type.haskell
-      , (!!)
---      ^^^^ variable.other.definition.field.haskell
+      , (  !!)
+--         ^^ variable.other.definition.field.haskell
 :: F, (+::) :: F
 -- <-- keyword.operator.double-colon.haskell
 -- ^ storage.type.haskell
 --     ^^^ variable.other.definition.field.haskell
 --          ^^ keyword.operator.double-colon.haskell
 --             ^ storage.type.haskell
-  , (++) :: F, -- no :: F, no :: F }
---  ^^^^ variable.other.definition.field.haskell
---       ^^ keyword.operator.double-colon.haskell
---          ^ storage.type.haskell
+  , ( ++ ) :: F, -- no :: F, no :: F }
+--    ^^ variable.other.definition.field.haskell
+--         ^^ keyword.operator.double-colon.haskell
+--            ^ storage.type.haskell
   (!::) :: F -- , no :: F} ,
--- <~~---  variable.other.definition.field.haskell
+-- <~~~---  variable.other.definition.field.haskell
 --         ^ storage.type.haskell
   }
 

--- a/test/tests/Imports.hs
+++ b/test/tests/Imports.hs
@@ -15,7 +15,7 @@ import M
   , pattern P
 --  ^^^^^^^ keyword.other.pattern.haskell
 --          ^ constant.other.haskell
-  , pattern (:|)
+  , pattern (:| )
 --  ^^^^^^^ keyword.other.pattern.haskell
 --           ^^ constant.other.haskell
   , pattern -- Q,)
@@ -28,14 +28,14 @@ import M
   , type T
 --  ^^^^ keyword.other.type.haskell
 --       ^ storage.type.haskell
-  , type (:-)
+  , type (:- )
 --  ^^^^ keyword.other.type.haskell
---        ^^ storage.type.operator.prefix.haskell
+--        ^^ storage.type.operator.haskell
   , type (<+>)
 --  ^^^^ keyword.other.type.haskell
---        ^^^ storage.type.operator.prefix.haskell
+--        ^^^ storage.type.operator.haskell
   , type {- T -}
 --  ^^^^ keyword.other.type.haskell
       (<->)
---    ^^^^^ storage.type.operator.prefix.haskell
+--     ^^^ storage.type.operator.haskell
   )

--- a/test/tests/Keywords.hs
+++ b/test/tests/Keywords.hs
@@ -5,7 +5,7 @@ anotherFunc :: MyData -> Int
 --                    ^^ keyword.operator.arrow.haskell
 anotherFunc arg = 
     let something = "hello" :: String
---                ^ keyword.operator.haskell
+--                ^ keyword.operator.eq.haskell
 --                          ^^ keyword.operator.double-colon.haskell
 --  ^^^ keyword.other.let.haskell
     in case a :: B of
@@ -13,7 +13,7 @@ anotherFunc arg =
 --            ^^ keyword.operator.double-colon.haskell
 --     ^^^^        ^^ keyword.control.haskell
         Just _ -> do
---             ^^ keyword.operator.haskell
+--             ^^ keyword.operator.arrow.haskell
 --                ^^ keyword.control.haskell
           if a
 --        ^^ keyword.control.haskell

--- a/test/tests/NearReserved.hs
+++ b/test/tests/NearReserved.hs
@@ -14,23 +14,22 @@ data a :==> b = a == b
 --                ^^ - keyword.operator.eq.haskell
 data a :==> b where
 --     ^^^^ - keyword.operator.eq.haskell keyword.operator.big-arrow.haskell
-  (:::) :: a ::: b -> c :==> d
--- ^^^       ^^^ - keyword.operator.double-colon.haskell
+  (::: ) :: a ::: b -> c :==> d
+-- ^^^^       ^^^ - keyword.operator.double-colon.haskell
 --                      ^^^^ - keyword.operator.eq.haskell keyword.operator.big-arrow.haskell
 
 f :: a ::: b =| c --> d -> e ==> b
---     ^^^ keyword.operator.double-colon.haskell
+--     ^^^ - keyword.operator.double-colon.haskell
 --           ^               ^^ - keyword.operator.eq.haskell
 --                 ^^ - keyword.operator.arrow.haskell
 --                            ^^ - keyword.operator.big-arrow.haskell
 
-
-(-::) :: a -> a -> a
--- <~--- - keyword.operator.double-colon.haskell
+( -:: ) :: a -> a -> a
+-- <------- - keyword.operator.double-colon.haskell
 a -:: b = a
 -- <~~--- - keyword.operator.double-colon.haskell
 
 (:::) :: a -> a -> a
--- <~--- keyword.operator.double-colon.haskell
+-- <~--- - keyword.operator.double-colon.haskell
 a ::: b = a
-  ^^^ - keyword.operator.double-colon.haskell
+--  <~~--- - keyword.operator.double-colon.haskell

--- a/test/tests/Ticks.hs
+++ b/test/tests/Ticks.hs
@@ -44,7 +44,7 @@
   type T = '(:+) '(AC.:+) 'AC.:++ 'AC.++
 --         ^     ^        ^ keyword.operator.promotion.haskell
 --                 ^^^     ^^^ entity.name.namespace.haskell
---           ^^       ^^ storage.type.operator.prefix.haskell
+--           ^^       ^^ storage.type.operator.haskell
 --                            ^^^     ^^ storage.type.operator.infix.haskell
 --         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ - invalid
 

--- a/test/tests/Tuples.hs
+++ b/test/tests/Tuples.hs
@@ -1,0 +1,12 @@
+-- SYNTAX TEST "source.haskell" "Tuple constructors"
+
+f = (,)
+--  ^^^ support.constant.tuple.haskell 
+f = (, )
+--  ^^^ support.constant.tuple.haskell 
+f = ( ,)
+--  ^^^^ support.constant.tuple.haskell 
+f = ( , , )
+--  ^^^^^^^ support.constant.tuple.haskell 
+f = (, , ,,,)
+--  ^^^^^^^^^ support.constant.tuple.haskell 

--- a/test/tests/TypeSigs.hs
+++ b/test/tests/TypeSigs.hs
@@ -2,47 +2,69 @@
 
 f :: ( x :: Int ) -> Int
 -- <~~-- ^^ keyword.operator.double-colon.haskell
+--                ^^ keyword.operator.arrow.haskell
 --          ^^^      ^^^ storage.type.haskell
 f x = do
 --  ^ keyword.operator.eq.haskell
   let x :: Int
 --      ^^ keyword.operator.double-colon.haskell
 --         ^^^ storage.type.haskell
-      x = 3
+      x = A
 --      ^ keyword.operator.eq.haskell
+--        ^ constant.other.haskell
   let
     y :: Int
 --    ^^ keyword.operator.double-colon.haskell
 --       ^^^ storage.type.haskell
-    y = 3
+    y = A
 --    ^ keyword.operator.eq.haskell
-    z :: Int = 3
+--      ^ constant.other.haskell
+    z :: Int = A
 --    ^^ keyword.operator.double-colon.haskell
 --       ^^^ storage.type.haskell
-    ( w :: Int ) = 4
+--           ^ keyword.operator.eq.haskell
+--             ^ constant.other.haskell
+    z :: Int == A
+--    ^^ keyword.operator.double-colon.haskell
+--       ^^^ storage.type.haskell
+--           ^^ storage.type.operator.infix.haskell
+--           ^^ - keyword.operator.eq.haskell
+--              ^ storage.type.haskell
+    ( w :: Int ) = A
 --      ^^ keyword.operator.double-colon.haskell
 --         ^^^ storage.type.haskell
 --               ^ keyword.operator.eq.haskell
-  x :: Int <- 3
+--                 ^ constant.other.haskell
+  x :: Int <- A
 --  ^^ keyword.operator.double-colon.haskell
 --     ^^^ storage.type.haskell
---         ^^ keyword.operator.haskell
-  ( x :: Int ) <- 4
+--         ^^ keyword.operator.arrow.left.haskell
+--            ^ constant.other.haskell
+  x :: Int <-- A
+--  ^^ keyword.operator.double-colon.haskell
+--         ^^^ storage.type.operator.infix.haskell
+--         ^^^ - keyword.operator.arrow.left.haskell
+--     ^^^     ^ storage.type.haskell
+--            
+  ( x :: Int ) <- A
 --    ^^ keyword.operator.double-colon.haskell
 --       ^^^ storage.type.haskell
---             ^^ keyword.operator.haskell
+--             ^^ keyword.operator.arrow.left.haskell
+--                ^ constant.other.haskell
   case x :: Int of
 --       ^^ keyword.operator.double-colon.haskell
 --          ^^^ storage.type.haskell
-    ( 2 :: Int ) -> 3
+    ( 2 :: Int ) -> A
 --      ^^ keyword.operator.double-colon.haskell
 --         ^^^ storage.type.haskell
---               ^^ keyword.operator.haskell
+--               ^^ keyword.operator.arrow.haskell
+--                  ^ constant.other.haskell
   where x :: Int
 --        ^^ keyword.operator.double-colon.haskell
 --           ^^^ storage.type.haskell
-        x = 3
+        x = A
 --        ^ keyword.operator.eq.haskell
+--          ^ constant.other.haskell
   where
     y :: Int
 --    ^^ keyword.operator.double-colon.haskell

--- a/test/tests/TypeVsData.hs
+++ b/test/tests/TypeVsData.hs
@@ -21,12 +21,12 @@ x :: T ->
 --    ^ storage.type.haskell
 
 y
-    :: T ->
+  :: T ->
 
   -- comment
   {-
     comment
   -}
 
-        T
+      T
 --    ^ storage.type.haskell

--- a/test/tickets/T0028.hs
+++ b/test/tickets/T0028.hs
@@ -4,6 +4,6 @@ someFunc :: IO ()
 someFunc = do
   result <- ioAction
   result :: Int <- ioAction
---              ^^ keyword.operator.haskell
+--              ^^ keyword.operator.arrow.left.haskell
   ( result :: Int ) <- ioAction
---                  ^^ keyword.operator.haskell
+--                  ^^ keyword.operator.arrow.left.haskell

--- a/test/tickets/T0028b.hs
+++ b/test/tickets/T0028b.hs
@@ -4,8 +4,8 @@ someFunc :: IO ()
 someFunc = do
   result <- ioAction
   result :: Int <- ioAction
--- <~~------ meta.function.type-declaration.haskell
 --          ^^^ storage.type.haskell
+--              ^^ keyword.operator.arrow.left.haskell
   ( result :: Int ) <- ioAction
 --            ^^^ storage.type.haskell
---  ^^^^^^ meta.function.type-declaration.haskell
+--                  ^^ keyword.operator.arrow.left.haskell

--- a/test/tickets/T0029.hs
+++ b/test/tickets/T0029.hs
@@ -2,5 +2,5 @@
 
 f = do
   rec a <- go a
--- <~~--- keyword.other.haskell
+-- <~~--- keyword.control.haskell
   return a

--- a/test/tickets/T0039b.hs
+++ b/test/tickets/T0039b.hs
@@ -1,15 +1,15 @@
 -- SYNTAX TEST "source.haskell" "forall dot not parsed as an operator"
 
 f :: forall a. a
---           ^ - keyword.operator.period.haskell
+--           ^ keyword.operator.period.haskell
 g :: forall a . a -> ( forall b . b ) -> a
---            ^                 ^ - keyword.operator.period.haskell
+--            ^                 ^ keyword.operator.period.haskell
 
 data Exts = forall var . Class var => Exts var
 --          ^^^^^^ keyword.other.forall.haskell
---                     ^ - keyword.operator.period.haskell
+--                     ^ keyword.operator.period.haskell
 
 data Exts where 
     F :: forall var . Class var => Exts var
 --       ^^^^^^ keyword.other.forall.haskell
---                  ^ - keyword.operator.period.haskell
+--                  ^ keyword.operator.period.haskell

--- a/test/tickets/T0069.hs
+++ b/test/tickets/T0069.hs
@@ -1,11 +1,11 @@
 -- SYNTAX TEST "source.haskell" "Parentheses in import and export lists"
 module Main (
    Foo((+-)), func1
---     ^^^^ meta.declaration.exports.haskell entity.name.function.infix.haskell
+--      ^^ meta.declaration.exports.haskell entity.name.function.infix.haskell
 --            ^^^^^ meta.declaration.exports.haskell entity.name.function.haskell
 --            ^^^^^ - invalid
    , Bar((:->), (:->>)), Baz, func5
---       ^^^^^  ^^^^^^ meta.declaration.exports.haskell entity.name.function.infix.haskell
+--        ^^^    ^^^^ meta.declaration.exports.haskell entity.name.function.infix.haskell
 --                       ^^^ meta.declaration.exports.haskell storage.type.haskell
 --                            ^^^^^ meta.declaration.exports.haskell entity.name.function.haskell
     ) where

--- a/test/tickets/T0070.hs
+++ b/test/tickets/T0070.hs
@@ -1,11 +1,11 @@
 -- SYNTAX TEST "source.haskell" "Custom operators"
 
-data (:->)
---    ^^^ meta.declaration.adt.haskell storage.type.haskell
-data (:=>) a b c = D
---    ^^^ meta.declaration.adt.haskell storage.type.haskell
---         ^ ^ ^ variable.other.generic-type.haskell
---                 ^ constant.other.haskell
+data (:-> )
+--    ^^^ meta.declaration.adt.haskell storage.type.operator.haskell
+data ( :=>) a b c = D
+--     ^^^ meta.declaration.adt.haskell storage.type.operator.haskell
+--          ^ ^ ^ variable.other.generic-type.haskell
+--                  ^ constant.other.haskell
 
 f :: a :-> b -> c :=> e
 --     ^^^ storage.type.operator.infix.haskell

--- a/test/tickets/T0131.hs
+++ b/test/tickets/T0131.hs
@@ -3,7 +3,7 @@
 {-@ incr :: x:Nat -> {v:Nat | v > x} @-}
 -- <--------------------------------------- block.liquidhaskell.haskell
 --       ^^ keyword.operator.double-colon.haskell
---                ^^ keyword.operator.haskell
+--                ^^ keyword.operator.arrow.haskell
 --  -------------------------------- - comment.block.haskell
 incr :: Int -> Int 
 incr x = x + 1 

--- a/test/tickets/T0136.hs
+++ b/test/tickets/T0136.hs
@@ -5,7 +5,7 @@ f :: proxy ( 'CD a b ) -> proxy ( a '`CD` b )
 --                                    ^^ storage.type.infix.haskell
 --           ^                      ^ keyword.operator.promotion.haskell
 
-g :: proxy ( '(:<) a b ) -> proxy ( a ':< b )
---             ^^ storage.type.operator.prefix.haskell
---                                     ^^ storage.type.operator.infix.haskell
---           ^                        ^ keyword.operator.promotion.haskell
+g :: proxy ( '(:< ) a b ) -> proxy ( a ':< b )
+--             ^^ storage.type.operator.haskell
+--                                      ^^ storage.type.operator.infix.haskell
+--           ^                         ^ keyword.operator.promotion.haskell


### PR DESCRIPTION
- Improves support for highlighting reserved operators:

```haskell
a <- b
```

```haskell
a -> b
```

```haskell
a = b
```

```haskell
\ a -> b
```

```haskell
a -< b
```

```haskell
a -<< b
```

- Fixes a bug where we would look ahead for a reserved operator such as `<-` but would match on something like `<--`.  That's been added to the tests.

- Fixes issues with highlighting type signatures: now a double-colon properly starts off the `type-signature` matching. It's still not perfect, as it would be good if it kept going on multiple lines (keeping track of indentation), so that it would still highlight properly something like:

```haskell
foo
  :: forall a b
  .  C x
  => D a
  => E b
  -> G
```
(barring the problems with the first line which can't really be addressed).

- Adds support for prefix data constructors in data declarations, like

```haskell
data (:&) a b = (:&) a b
```

No support for infix definitions at the moment, which seems kind of annoying to do. Slowly inching towards fixing [T0132](https://github.com/JustusAdam/language-haskell/blob/024c95d/test/tickets/T0132.hs)...

- Fixes a small issue with type signatures: don't allow them to start with `::` if there are further symbols (e.g. `a ::: b` is not a type signature).