### PR TITLE
Allow CPP in module exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Fixed several issues involving multi-line type/data declarations,
   including allowing intervening comments ([#147](https://github.com/JustusAdam/language-haskell/pull/147)).
 - Add support for visible kind application (and miscellaneous fixes for visible type application).
+- Allow C preprocessor instructions to appear in module exports.
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -37,6 +37,7 @@ patterns:
       '1': {name: keyword.other.where.haskell}
     name: meta.declaration.module.haskell
     patterns:
+      - include: '#cpp'
       - include: '#module_name'
       - include: '#module_exports'
       - include: '#pragma'
@@ -389,11 +390,7 @@ patterns:
     name: keyword.control.haskell
   - include: '#numeric_literals'
   - include: '#type_application'
-  - captures:
-      '1': {name: punctuation.definition.preprocessor.c}
-    comment: 'In addition to Haskell''s "native" syntax, GHC permits the C preprocessor to be run on a source file.'
-    match: '^\s*(#)\s*\w+'
-    name: meta.preprocessor.c
+  - include: '#cpp'
   - include: '#pragma'
   - include: '#string_literal'
   - captures:
@@ -488,6 +485,12 @@ repository:
             end: \n
             name: comment.line.double-dash.haskell
       - {include: '#block_comment'}
+  cpp:
+    captures:
+      '1': {name: punctuation.definition.preprocessor.c}
+    comment: 'In addition to Haskell''s "native" syntax, GHC permits the C preprocessor to be run on a source file.'
+    match: '^\s*(#).*$'
+    name: meta.preprocessor.c
   deriving:
     patterns:
       - begin: '(deriving)(?:\s+(stock|newtype|anyclass))?\s*\('
@@ -532,6 +535,7 @@ repository:
         captures:
           '1': {name: keyword.other.module.haskell}
       - include: '#comma'
+      - include: '#cpp'
       - include: '#export_constructs'
       - begin: '\('
         end: '\)'

--- a/test/tests/CPP.hs
+++ b/test/tests/CPP.hs
@@ -1,0 +1,20 @@
+-- SYNTAX TEST "source.haskell" "C preprocessor instructions"
+
+module M
+  ( A
+  , a
+#ifdef XYZ
+-- <----- meta.preprocessor.c
+  , bcd
+  , X
+#endif
+-- <----- meta.preprocessor.c
+  )
+  where
+
+#if MIN_VERSION_BASE(4,12,0)
+-- <-- meta.preprocessor.c
+foo :: A
+foo = A
+#endif
+-- <----- meta.preprocessor.c


### PR DESCRIPTION
Allows C preprocessor instructions to appear in module exports.

Also highlights the whole line, instead of falling back to Haskell highlighting (which looked wonky at times).
