### PR TITLE
Improvements to foreign import/export declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Support for Haddock documentation heralds `*`, `^`, `$`.
 - Fix regression for comments inside record definitions ([#131](https://github.com/JustusAdam/language-haskell/issues/136))
 - Improved support for reserved symbolic operators.
+- Improve highlighting in foreign import/export declaration:
+   - more calling conventions recognised,
+   - recognise safe/unsafe/interruptible keywords,
+   - correct highlighting of type signature, including over multiple lines.
 
 ## 3.0.0 - 26.04.2020
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -38,6 +38,7 @@ patterns:
       - include: '#module_exports'
       - match: '[a-z]+'
         name: invalid
+  - include: '#ffi'
   - begin: '\b(class)(\b(?!''))'
     beginCaptures:
       '1': {name: keyword.other.class.haskell}
@@ -101,6 +102,7 @@ patterns:
                            # then it would be an operator, not a comment
               )
         patterns:
+          - include: '#comment_like'
           - include: '#double_colon'
           - include: '#record_decl'
           - include: '#type_signature'
@@ -376,18 +378,16 @@ patterns:
     name: meta.import.haskell
     patterns:
       - include: '#comment_like'
-      - match: (qualified)|(as)|(hiding)
+      - match: (qualified|as|hiding)
         captures:
-          '1': {name: keyword.other.qualified.haskell}
-          '2': {name: keyword.other.as.haskell}
-          '3': {name: keyword.other.hiding.haskell}
+          '1': {name: "keyword.other.$1.haskell"}
       - include: '#module_name'
       - include: '#module_exports'
   - include: '#deriving'
   - match: '\b(deriving)\s+(via)\s+(.*)\s+(instance)\b\s+(.*)$'
     captures:
       '1': {name: keyword.other.deriving.haskell}
-      '2': {name: keyword.other.via.haskell}
+      '2': {name: keyword.other.deriving.strategy.via.haskell}
       '3': {patterns: [{include: '#type_signature'}]}
       '4': {name: keyword.other.instance.haskell}
       '5': {patterns: [{include: '#type_signature'}]}
@@ -483,13 +483,6 @@ patterns:
       '2': {name: entity.name.namespace.haskell}
       '3': {name: keyword.operator.haskell}
   - include: '#comma'
-  - match: '^\s*(foreign)\s+(?:(import)|(export))\s+(ccall|cplusplus|dotnet|jvm|stdcall)\b(?!'')'
-    name: meta.import.foreign.haskell
-    captures:
-      '1': {name: keyword.other.foreign.haskell}
-      '2': {name: keyword.other.import.haskell}
-      '3': {name: keyword.other.export.haskell}
-      '4': {name: keyword.other.calling-convention.haskell}
 repository:
   block_comment:
     applyEndPatternLast: 1
@@ -553,7 +546,7 @@ repository:
       - begin: '(deriving)(?:\s+(stock|newtype|anyclass))?\s*\('
         beginCaptures:
           '1': {name: keyword.other.deriving.haskell}
-          '2': {name: keyword.other.deriving-strategy.haskell}
+          '2': {name: "keyword.other.deriving.strategy.$2.haskell"}
         end: \)
         name: meta.deriving.haskell
         patterns:
@@ -566,9 +559,9 @@ repository:
               (\s+(via)\s+(.*)$)?
         captures:
           '1': {name: keyword.other.deriving.haskell}
-          '2': {name: keyword.other.deriving-strategy.haskell}
+          '2': {name: "keyword.other.deriving.strategy.$2.haskell"}
           '3': {patterns: [{include: '#type_signature'}]}
-          '5': {name: keyword.other.via.haskell}
+          '5': {name: keyword.other.deriving.strategy.via.haskell}
           '6': {patterns: [{include: '#type_signature'}]}
         name: meta.deriving.haskell
   infix_op:
@@ -963,5 +956,86 @@ repository:
     patterns:
       - include: '#integer_literals'
       - include: '#float_literals'
+
+  ffi:
+    begin: '^(\s*)(foreign)\s+(import|export)\s+'
+    beginCaptures:
+      '2': {name: keyword.other.foreign.haskell}
+      '3': {name: "keyword.other.$3.haskell"}
+    name: meta.$3.foreign.haskell
+    end: |
+      (?x)
+         ^(?!          # It ends *unless* the *new* line is:
+            \1\s+\S    # - Some haskell stuff, but more indented (continuation)
+          | \s*        # - Only a little bit of whitespace followed by
+            (?: $      #   - The end of the line (i.e. empty line)
+            | \{-      #   - The start of a block comment
+            |--+       #   - The start of a single-line comment
+               (?![\p{S}\p{P}&&[^(),;\[\]`{}_"']]).*$)
+                       # The double dash may not be followed by other operator characters,
+                       # then it would be an operator, not a comment
+          )
+    patterns:
+      - include: '#comment_like'
+      - match: '\b(ccall|cplusplus|dotnet|jvm|stdcall|prim|capi)\s+'
+        captures:
+          '1': {name: "keyword.other.calling-convention.$1.haskell"}
+      - begin: '(?=")|(?=\b([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}'']*)\b(?!''))'
+        end: '(?=(::|∷)(?![\p{S}\p{P}&&[^(),;\[\]`{}_"'']]))'
+        patterns:
+          # safe/unsafe/interruptible keywords,
+          # but we must take care to still allow a function named "safe" without such a keyword
+          # for instance:
+          #
+          # foreign import ccall safe foo :: ...
+          #                      ^^^^ keyword
+          #
+          # foreign import ccall safe :: ...
+          #                      ^^^^ not a keyword
+          - include: '#comment_like'
+          - match: |
+              (?x)
+                \b(safe|unsafe|interruptible)\b(?!')
+                \s*
+                (?:(")(.*[^\\])("))?
+                \s*
+                (?:
+                  (?:\b([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)\b(?!'))
+                 |(?:\(\s*(?!--+\))([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\))
+                )
+            captures:
+              '1': {name: "keyword.other.safety.$1.haskell"}
+              '2': {name: "punctuation.definition.string.begin.haskell string.quoted.double.haskell"}
+              '3': {name: "entity.name.foreign.haskell string.quoted.double.haskell" }
+              '4': {name: "punctuation.definition.string.end.haskell string.quoted.double.haskell"}
+              '5': {name: entity.name.function.haskell}
+              '6': {name: entity.name.function.infix.haskell}
+          # Assume that if there is no function name on this line, it will appear on the next line
+          - match: |
+              (?x)
+                \b(safe|unsafe|interruptible)\b(?!')
+                \s*
+                (?:(")(.*[^\\])("))?
+                \s*$
+            captures:
+              '1': {name: "keyword.other.safety.$1.haskell"}
+              '2': {name: "punctuation.definition.string.begin.haskell string.quoted.double.haskell"}
+              '3': {name: "entity.name.foreign.haskell string.quoted.double.haskell" }
+              '4': {name: "punctuation.definition.string.end.haskell string.quoted.double.haskell"}
+          - match: '(?:(")(.*[^\\])("))'
+            captures:
+              '1': {name: "punctuation.definition.string.begin.haskell string.quoted.double.haskell"}
+              '2': {name: "entity.name.foreign.haskell string.quoted.double.haskell" }
+              '3': {name: "punctuation.definition.string.end.haskell string.quoted.double.haskell"}
+          - match: |
+              (?x)
+                 (?:\b([\p{Ll}_][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*)\b(?!'))
+                |(?:\(\s*(?!--+\))([\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*\))
+            captures:
+              '1': {name: entity.name.function.haskell}
+              '2': {name: entity.name.function.infix.haskell}
+      - include: '#double_colon'
+      - include: '#type_signature'
+      
 scopeName: source.haskell
 uuid: 5C034675-1F6D-497E-8073-369D37E2FD7D

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,7 +19,6 @@ ticketsBroken=(
   "T0028c.hs"
   "T0039b.hs"
   "T0043b.hs"
-  "T0044.hs"
   "T0072b2.hs"
   "T0072c.hs"
   "T0132.hs"

--- a/test/tickets/T0044.hs
+++ b/test/tickets/T0044.hs
@@ -4,51 +4,75 @@
 
     foreign import jvm "string.h strlen"
 --  ^^^^^^^ keyword.other.foreign.haskell
---  ^^^^^^^^^^^^^^^^^^ meta.import.foreign.haskell
+--          ^^^^^^ keyword.other.import.haskell
+--                 ^^^ keyword.other.calling-convention.jvm.haskell
+--                      ^^^^^^^^^^^^^^^ entity.name.foreign.haskell string.quoted.double.haskell
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.foreign.haskell
         cstrlen :: Ptr CChar -> IO CSize 
---      ^^^^^^^    ^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
-    foreign import stdcall "string.h strlen"
+--      ^^^^^^^ entity.name.function.haskell
+--              ^^ keyword.operator.double-colon.haskell
+--                 ^^^ ^^^^     ^^ ^^^^^ storage.type.haskell
+--      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.foreign.haskell
+
+    foreign export stdcall "string.h strlen" foo :: Ptr CInt
 --  ^^^^^^^ keyword.other.foreign.haskell
---  ^^^^^^^^^^^^^^^^^^ meta.import.foreign.haskell
+--          ^^^^^^ keyword.other.export.haskell
+--                 ^^^^^^^ keyword.other.calling-convention.stdcall.haskell
+--                          ^^^^^^^^^^^^^^^ entity.name.foreign.haskell string.quoted.double.haskell
+--                                           ^^^ entity.name.function.haskell
+--                                               ^^ keyword.operator.double-colon.haskell
+--                                                  ^^^ ^^^^ storage.type.haskell
+--  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.export.foreign.haskell
 
-foreign import ccall "string.h strlen"
+foreign import ccall safe "string.h strlen"
 -- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                   ^^^^^^^^^^^^^^^^^ string.quoted.double.haskell
+--      ^^^^^^ keyword.other.import.haskell
+--             ^^^^^ keyword.other.calling-convention.ccall.haskell
+--                   ^^^^ keyword.other.safety.safe.haskell
+--                         ^^^^^^^^^^^^^^^^^ string.quoted.double.haskell
+-- <-------------------------------------- meta.import.foreign.haskell
+
    cstrlen :: Ptr CChar -> IO CSize
--- ^^^^^^^    ^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
+-- ^^^^^^^ entity.name.function.haskell
+--            ^^^ ^^^^^    ^^ ^^^^^ storage.type.haskell
+-- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.import.foreign.haskell
 
-foreign export cplusplus  "string.h strlen"
+foreign export cplusplus "string.h strlen" foo :: Ptr CInt
 -- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                        ^^^^^^^^^^^^^^^^^ string.quoted.double.haskell
-foreign import dotnet "string.h strlen"
--- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                    ^^^^^^^^^^^^^^^^^ string.quoted.double.haskell
+--      ^^^^^^ keyword.other.export.haskell
+--             ^^^^^^^^^ keyword.other.calling-convention.cplusplus.haskell
+--                         ^^^^^^^^^^^^^^ entity.name.foreign.haskell string.quoted.double.haskell
+--                                         ^^^ entity.name.function.haskell
+--                                             ^^ keyword.operator.double-colon.haskell
+--                                                ^^^ ^^^^ storage.type.haskell
+-- <----------------------------------------------------------- meta.export.foreign.haskell
 
-foreign import ccall "errno.h &errno" errno :: Ptr CInt
+foreign export ccall "addInt" (+) :: Int   -> Int   -> Int
 -- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                   ^^^^^^^^^^^^^^^^ string.quoted.double.haskell
---                                    ^^^^^^  ^^^^^^^^^ meta.function.type-declaration.haskell
-foreign import ccall "&" bar :: Ptr CInt
+--      ^^^^^^ keyword.other.export.haskell
+--             ^^^^^ keyword.other.calling-convention.ccall.haskell
+--                    ^^^^^^  entity.name.foreign.haskell string.quoted.double.haskell
+--                             ^ entity.name.function.infix.haskell
+--                                ^^ keyword.operator.double-colon.haskell
+--                                   ^^^      ^^^      ^^^ storage.type.haskell
+-- <---------------------------------------------------------- meta.export.foreign.haskell
+foreign export prim interruptible "addFloat" (+) :: Float -> Float -> Float
 -- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                   ^^^ string.quoted.double.haskell
---                       ^^^^  ^^^^^^^^^ meta.function.type-declaration.haskell
-foreign import capi foo :: CInt
--- <------- keyword.other.foreign.haskell
--- <-------------------- meta.import.foreign.haskell
---                   ^^^^  ^^^^^ meta.function.type-declaration.haskell
+--      ^^^^^^ keyword.other.export.haskell
+--                  ^^^^^^^^^^^^^ keyword.other.safety.interruptible.haskell
+--                                 ^^^^^^^^ entity.name.foreign.haskell string.quoted.double.haskell
+--                                            ^ entity.name.function.infix.haskell
+--                                               ^^ keyword.operator.double-colon.haskell
+--                                                  ^^^^^    ^^^^^     ^^^^^ storage.type.haskell
+-- <--------------------------------------------------------------------------- meta.export.foreign.haskell
 
-foreign export ccall "addInt"   (+) :: Int   -> Int   -> Int
--- <------- keyword.other.foreign.haskell
--- <-------------------- meta.export.foreign.haskell
---                   ^^^^^^^^ string.quoted.double.haskell
---                              ^^^^  ^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
-foreign export prim unsafe "addFloat" (+) :: Float -> Float -> Float
--- <------- keyword.other.foreign.haskell
--- <-------------------- meta.export.foreign.haskell
---                   ^^^^^^^^^^ string.quoted.double.haskell
---                              ^^^^  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.type-declaration.haskell
+
+
+foreign export ccall safe :: Int -> Int
+--                   ^^^^ - keyword.other.safety.safe.haskell
+--                   ^^^^ entity.name.function.haskell
+
+foreign export ccall "unsafe" unsafe :: Int -> Int
+--                    ^^^^^^ entity.name.foreign.haskell string.quoted.double.haskell
+--                            ^^^^^^ - keyword.other.safety.unsafe.haskell
+--                            ^^^^^^ entity.name.function.haskell

--- a/test/tickets/T0072b.hs
+++ b/test/tickets/T0072b.hs
@@ -2,21 +2,21 @@
 
 deriving via (A b c) instance C a
 -- <------- keyword.other.deriving.haskell
---       ^^^ keyword.other.via.haskell
+--       ^^^ keyword.other.deriving.strategy.via.haskell
 --                   ^^^^^^^^ keyword.other.instance.haskell
 --            ^               ^ storage.type.haskell
 --              ^ ^             ^ variable.other.generic-type.haskell
 
 deriving via Base a instance C ( Total a )
 -- <------- keyword.other.deriving.haskell
---       ^^^ keyword.other.via.haskell
+--       ^^^ keyword.other.deriving.strategy.via.haskell
 --                  ^^^^^^^^ keyword.other.instance.haskell
 --           ^^^^            ^   ^^^^^ storage.type.haskell
 --                ^                    ^ variable.other.generic-type.haskell
 
 deriving via '(F A, B) instance R '(A, G B)
 -- <------- keyword.other.deriving.haskell
---       ^^^ keyword.other.via.haskell
+--       ^^^ keyword.other.deriving.strategy.via.haskell
 --                     ^^^^^^^^ keyword.other.instance.haskell
 --             ^ ^  ^           ^   ^  ^ ^ storage.type.haskell
 
@@ -24,15 +24,15 @@ deriving via '(F A, B) instance R '(A, G B)
 data B = B
     deriving A via B
 --  ^^^^^^^^ keyword.other.deriving.haskell
---             ^^^ keyword.other.via.haskell
+--             ^^^ keyword.other.deriving.strategy.via.haskell
 --           ^     ^ storage.type.haskell
     deriving stock    ( Eq, Generic )
 --  ^^^^^^^^ keyword.other.deriving.haskell
---           ^^^^^ keyword.other.deriving-strategy.haskell
+--           ^^^^^ keyword.other.deriving.strategy.stock.haskell
 --                      ^^  ^^^^^^^ storage.type.haskell
     deriving anyclass NFData
 --  ^^^^^^^^ keyword.other.deriving.haskell
---           ^^^^^^^^ keyword.other.deriving-strategy.haskell
+--           ^^^^^^^^ keyword.other.deriving.strategy.anyclass.haskell
 --                    ^^^^^^ storage.type.haskell
 
 newtype N a = MkN a

--- a/test/tickets/T0072b2.hs
+++ b/test/tickets/T0072b2.hs
@@ -2,15 +2,15 @@
 
 data B = B deriving A via B
 --         ^^^^^^^^ keyword.other.deriving.haskell
---                    ^^^ keyword.other.via.haskell
+--                    ^^^ keyword.other.deriving.strategy.via.haskell
 --                  ^     ^ storage.type.haskell
 data B = B deriving stock    ( Eq, Generic )
 --         ^^^^^^^^ keyword.other.deriving.haskell
---                  ^^^^^ keyword.other.deriving-strategy.haskell
+--                  ^^^^^ keyword.other.deriving.strategy.stock.haskell
 --                             ^^  ^^^^^^^ storage.type.haskell
 data B = B deriving anyclass NFData
 --         ^^^^^^^^ keyword.other.deriving.haskell
---                  ^^^^^^^^ keyword.other.deriving-strategy.haskell
+--                  ^^^^^^^^ keyword.other.deriving.strategy.anyclass.haskell
 --                           ^^^^^^ storage.type.haskell
 
 newtype StateMonad b c r = StateMonad (StateT (MyState (Something b c) b) IO r)

--- a/test/tickets/T0151.hs
+++ b/test/tickets/T0151.hs
@@ -1,0 +1,6 @@
+-- SYNTAX TEST "source.haskell" "Constructors and parentheses"
+
+fail = S (S Z)
+--     ^  ^ ^ constant.other.haskell
+success = S (S Z )
+--        ^  ^ ^ constant.other.haskell


### PR DESCRIPTION
I've rewritten the support for `foreign import`/`foreign export` to be a bit more robust, especially to handle highlighting of type signatures when written over multiple lines.

A bit of complexity to do with highlighting optional `safe`/`unsafe`/`interruptible` keywords while not highlighting them when they are the name of the function instead (which is allowed).