### PR TITLE
allow indentation on `\begin{code}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix lists of the form ['|'...] being highlighted as quasiquotations
   ([#170](https://github.com/JustusAdam/language-haskell/issues/170)).
 - Proper highlighting of lambda case, including fixing the highlighting of subsequent braces (which were wrongly highlighted as record syntax).
+- Recognize indented `\begin{code}` and `\end{code}` boundaries in literate haskell files.
 
 ## 3.3.0 - 25.06.2020
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Fix lists of the form ['|'...] being highlighted as quasiquotations
   ([#170](https://github.com/JustusAdam/language-haskell/issues/170)).
 - Proper highlighting of lambda case, including fixing the highlighting of subsequent braces (which were wrongly highlighted as record syntax).
-- Recognize indented `\begin{code}` and `\end{code}` boundaries in literate haskell files.
+- Recognize indented `\begin{code}` boundary in literate haskell files.
 
 ## 3.3.0 - 25.06.2020
 

--- a/syntaxes/literateHaskell.YAML-tmLanguage
+++ b/syntaxes/literateHaskell.YAML-tmLanguage
@@ -10,7 +10,7 @@ patterns:
       '3': {name: punctuation.definition.arguments.begin.latex}
       '4': {name: punctuation.definition.arguments.end.latex}
     contentName: source.haskell.embedded.latex
-    end: '^\s*((\\)end)({)code(})'
+    end: '^((\\)end)({)code(})'
     name: meta.embedded.block.haskell.latex
     patterns:
       - {include: source.haskell}

--- a/syntaxes/literateHaskell.YAML-tmLanguage
+++ b/syntaxes/literateHaskell.YAML-tmLanguage
@@ -3,14 +3,14 @@ fileTypes:
 keyEquivalent: ^~H
 name: 'Literate Haskell'
 patterns:
-  - begin: '^((\\)begin)({)code(})(\s*\n)?'
+  - begin: '^\s*((\\)begin)({)code(})(\s*\n)?'
     captures:
       '1': {name: support.function.be.latex}
       '2': {name: punctuation.definition.function.latex}
       '3': {name: punctuation.definition.arguments.begin.latex}
       '4': {name: punctuation.definition.arguments.end.latex}
     contentName: source.haskell.embedded.latex
-    end: '^((\\)end)({)code(})'
+    end: '^\s*((\\)end)({)code(})'
     name: meta.embedded.block.haskell.latex
     patterns:
       - {include: source.haskell}

--- a/test/tickets/T0172.lhs
+++ b/test/tickets/T0172.lhs
@@ -1,18 +1,12 @@
 -- SYNTAX TEST "text.tex.latex.haskell" "Literate Haskell"
 
-> \ x -> x + x
--- <~~- keyword.operator.lambda.haskell
---    ^^ keyword.operator.arrow.haskell
---         ^ keyword.operator.infix.haskell
-
-\begin{code}
--- <------------ meta.embedded.block.haskell.latex
+    \begin{code}
+--  ^^^^^^^^^^^^ meta.embedded.block.haskell.latex
 \ x -> x + x
 -- <- keyword.operator.lambda.haskell
 --  ^^ keyword.operator.arrow.haskell
 --       ^ keyword.operator.infix.haskell
 \end{code}
--- <---------- meta.embedded.block.haskell.latex
 
 \ x -> x + x
 -- <- - keyword.operator.lambda.haskell


### PR DESCRIPTION
per https://gitlab.haskell.org/ghc/ghc/-/blob/master/utils/unlit/unlit.c#L203-228, ghc skips all leading whitespace before checking for `\begin{code}` but [apparently not `\end{code}`](https://gitlab.haskell.org/ghc/ghc/-/blob/master/utils/unlit/unlit.c#L271-282), so this is valid. there's a related [ghc issue](https://gitlab.haskell.org/ghc/ghc/-/issues/3549) from ten years ago but it looks like it's gone mostly ignored for a while.

not sure if existing test infrastructure can handle `.lhs` files, but it looks like it can't, so i'm not sure how i'd add a test.

(this is useful for me because i'm writing homework assignments as markdown-ish `.lhs` files and using pandoc to render out PDFs, but i need code blocks to be within lists or else everything turns out ugly.)