### PR TITLE
Default to .hs when saving Haskell files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x - Unreleased
 
 - Add support for Alex and Happy ([#97](https://github.com/JustusAdam/language-haskell/issues/97)), thanks to [@matthewess](https://github.com/matthewess).
+- Default to .hs when saving files ([#197](https://github.com/JustusAdam/language-haskell/issues/197)), thanks to [@noughtmare](https://github.com/noughtmare).
 
 ## 3.4.0 - 25.02.2021
 

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
           "haskell"
         ],
         "extensions": [
+          ".hs",
           ".hsig",
-          "hs-boot",
-          ".hs"
+          "hs-boot"
         ],
         "configuration": "./haskell-configuration.json"
       },


### PR DESCRIPTION
VSCode seems to use the first extension listed in the list of extensions as the default extension for saving files.

Fixes #197 