### PR TITLE
Improve custom quasi-quotation parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - Add support for Alex and Happy ([#97](https://github.com/JustusAdam/language-haskell/issues/97)), thanks to [@matthewess](https://github.com/matthewess).
 - Default to .hs when saving files ([#197](https://github.com/JustusAdam/language-haskell/issues/197)), thanks to [@noughtmare](https://github.com/noughtmare).
+- Fix highlighting for custom quasi quoters with immediate `|`
+  ([#203](https://github.com/JustusAdam/language-haskell/issues/203)).
 
 ## 3.4.0 - 25.02.2021
 

--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -1755,7 +1755,7 @@ repository:
             (?!'\|')                                             # Don't parse ['|'...] as a quasi quotation
             ((?:[\p{Lu}\p{Lt}][\p{Ll}_\p{Lu}\p{Lt}\p{Nd}']*\.)*) # Optional qualifier
             ((?:[^\s\p{S}\p{P}]|['_])*)                          # Quasi-quoter
-            (\|(?:\|(?!\]))?)
+            (\|)
         beginCaptures:
           '1': {name: keyword.operator.quasi-quotation.begin.haskell}
           '2': {name: keyword.operator.prefix.double-dollar.haskell}
@@ -1763,7 +1763,7 @@ repository:
           '4': {name: entity.name.namespace.haskell}
           '5': {name: entity.name.quasi-quoter.haskell}
           '6': {name: keyword.operator.quasi-quotation.begin.haskell}
-        end: '\6\]'
+        end: '\|\]'
         endCaptures:
           '0': {name: keyword.operator.quasi-quotation.end.haskell}
         name: "meta.quasi-quotation.haskell meta.embedded.block.$5"

--- a/test/tests/QuasiQuotes.hs
+++ b/test/tests/QuasiQuotes.hs
@@ -40,6 +40,13 @@
 --  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.quasi-quotation.haskell
 
 
+    [i|| A |]
+--  ^ ^ keyword.operator.quasi-quotation.begin.haskell
+--   ^ entity.name.quasi-quoter.haskell
+--     ^^^^ meta.quasi-quotation.haskell meta.embedded.block.i
+--         ^^ keyword.operator.quasi-quotation.end.haskell
+--  ^^^^^^^^^ meta.quasi-quotation.haskell
+
     [$html|
 --  ^     ^ keyword.operator.quasi-quotation.begin.haskell
 --    ^^^^ entity.name.quasi-quoter.haskell


### PR DESCRIPTION
Problem: currently parsing `[int||Text|]` fails with the current Haskell
grammar.

This happens, because we parse the beginning in a greedy way, and so
parse `[int||` as beginning of typed quasi-quoter. Thus end must be
`||]` respectively, but we never meet it.

Solution: custom quoters are never typed, and GHC (tried with 8.10.7
version) interprets `[int||Abc||]` as a mere quoter with `|Abc|` body.

So here we adjust the pattern for custom quoters to be never typed.

Resolves #203.