### PR TITLE
Add the untrustedWorkspaces capability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x - Unreleased
+
+- Add support for untrusted workspaces ([#211](https://github.com/JustusAdam/language-haskell/pull/211)), thanks to [@maciej-irl]
+
 ## 3.6.0 - 15.03.2022
 
 - Overwriting previous release due to a packaging error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## x.x.x - Unreleased
 
-- Add support for untrusted workspaces ([#211](https://github.com/JustusAdam/language-haskell/pull/211)), thanks to [@maciej-irl]
+- Add support for untrusted workspaces ([#211](https://github.com/JustusAdam/language-haskell/pull/211)), thanks to [@maciej-irl](http://github.com/maciej-irl)
 
 ## 3.6.0 - 15.03.2022
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
     "onLanguage:haskell"
   ],
   "main": "./out/src/extension",
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "contributes": {
     "configuration": {
       "type": "object",


### PR DESCRIPTION
As far as I can see there is nothing preventing this extension from supporting untrusted namespaces.

The only reason is this is not done automatically by VS Code is because of the [main entry point](https://code.visualstudio.com/api/extension-guides/workspace-trust#does-my-extension-have-a-main-entry-point), but I don't think we do anything in `extension.ts` the could be exploited by a malicious workspace.