### PR TITLE
WIP: remove -s from tests

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -65,32 +65,26 @@ runTests () {
 
       "hs" | "hs-boot" | "hsig" )
         syntaxes=( "$baseDir/syntaxes/haskell.json" )
-        source="source.haskell"
         ;;
 
       "cabal" )
         syntaxes=( "$baseDir/syntaxes/cabal.json" )
-        source="source.cabal"
         ;;
 
       "lhs" )
         syntaxes=( "$baseDir/syntaxes/haskell.json" "$baseDir/syntaxes/literateHaskell.json" )
-        source="text.tex.latex.haskell"
         ;;
 
       "x" )
         syntaxes=( "$baseDir/syntaxes/alex.json" "$baseDir/syntaxes/haskell.json" )
-        source="source.haskell.alex"
         ;;
 
       "y" )
         syntaxes=( "$baseDir/syntaxes/happy.json" "$baseDir/syntaxes/haskell.json" )
-        source="source.haskell.happy"
         ;;
 
       * )
         syntaxes=()
-        source=""
         ;;
 
     esac
@@ -104,7 +98,7 @@ runTests () {
         specifySyntaxes="$specifySyntaxes -g $i"
       done
       # Run the test.
-      result=$(npx vscode-tmgrammar-test -s "$source" $specifySyntaxes -t "$filepath")
+      result=$(npx vscode-tmgrammar-test $specifySyntaxes "$filepath")
       # Check test result by inspecting the exit code of the previous command.
       status=$?
       if [ $status -eq 0 ]

--- a/test/tests/Keywords.hs
+++ b/test/tests/Keywords.hs
@@ -22,9 +22,10 @@ anotherFunc arg =
           then b
 --        ^^^^ keyword.control.then.haskell
           else \cases
+--        ^^^^ keyword.control.else.haskell
 --              ^^^^^ keyword.control.cases.haskell
             arg1 arg2 -> undefined
---        ^^^^ keyword.control.else.haskell
+
   where 
 -- <~~----- keyword.other.where.haskell
     expression argument = arg + 7


### PR DESCRIPTION
It seems this is no longer supported by `vscode-tmgrammar-test`? Let's see if CI passes with this change.