### PR TITLE
Infix operators can end with #

### DIFF
--- a/syntaxes/haskell.YAML-tmLanguage
+++ b/syntaxes/haskell.YAML-tmLanguage
@@ -590,7 +590,7 @@ repository:
           instead, it should be matched as a comment.
         match: >-
           (?x)
-            (\()\s*(?!(?:--+|\.\.)\))(\#+|[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+(?<!\#))\s*(\))
+            (\()\s*(?!(?:--+|\.\.)\))(\#+|[\p{S}\p{P}&&[^(),;\[\]`{}_"']]+)\s*(\))
         captures:
           '1': {name: punctuation.paren.haskell}
           '2': {name: entity.name.function.infix.haskell}

--- a/test/tests/ExportsMagicHash.hs
+++ b/test/tests/ExportsMagicHash.hs
@@ -9,6 +9,7 @@ module M
 --          ^ constant.other.haskell
   , f#, (+#), T#
 --  ^ entity.name.function.haskell
+--       ^^ entity.name.function.infix.haskell
 --            ^ storage.type.haskell
   , type T#
 --  ^^^^ keyword.other.type.haskell


### PR DESCRIPTION
Fixes #230. Infix operators can include `#` characters even when `MagicHash` is not enabled.